### PR TITLE
Support Jira Cloud in assignee resolution

### DIFF
--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -54,6 +54,28 @@ class JiraService:
             self.jira = JIRA(server=self.jira_url, token_auth=self.jira_token)
         self._field_map: dict[str, str] | None = None
         self._status_name_map: dict[str, str] | None = None
+        self._is_cloud = "atlassian.net" in self.jira_url
+
+    def _resolve_assignee(self, assignee: str) -> dict[str, str]:
+        """Resolve an assignee string to the correct Jira field format.
+
+        Jira Cloud requires {"accountId": "..."} while Jira Server/DC
+        uses {"name": "..."}.
+        """
+        if not self._is_cloud:
+            return {"name": assignee}
+
+        users = self.jira._session.get(
+            f"{self.jira_url}/rest/api/2/user/search",
+            params={"query": assignee, "maxResults": 1},
+        ).json()
+        if users:
+            return {"accountId": users[0]["accountId"]}
+
+        raise ValueError(
+            f"Could not find Jira Cloud user matching '{assignee}'. "
+            "Provide an email address or display name."
+        )
 
     def get_forge_field_options(
         self,
@@ -402,7 +424,7 @@ class JiraService:
             if components is not None:
                 fields["components"] = [{"name": c} for c in components]
             if assignee is not None:
-                fields["assignee"] = {"name": assignee}
+                fields["assignee"] = self._resolve_assignee(assignee)
 
             issue = self.jira.create_issue(fields=fields)
             return {
@@ -453,7 +475,7 @@ class JiraService:
             if components is not None:
                 fields["components"] = [{"name": c} for c in components]
             if assignee is not None:
-                fields["assignee"] = {"name": assignee}
+                fields["assignee"] = self._resolve_assignee(assignee)
 
             # Resolve human-readable custom field names to IDs
             if custom_fields:

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -574,6 +574,7 @@ def test_create_issue_with_optional_fields():
     mock_issue.key = "TEST-1000"
     mock_issue.fields.summary = "Full ticket"
     svc.jira.create_issue.return_value = mock_issue
+    svc.jira._session.get.return_value.json.return_value = [{"accountId": "abc123"}]
 
     result = svc.create_issue(
         project_key="TEST",
@@ -594,7 +595,7 @@ def test_create_issue_with_optional_fields():
     assert call_fields["priority"] == {"name": "Critical"}
     assert call_fields["labels"] == ["label1", "label2"]
     assert call_fields["components"] == [{"name": "comp1"}]
-    assert call_fields["assignee"] == {"name": "jsmith"}
+    assert call_fields["assignee"] == {"accountId": "abc123"}
     assert result["key"] == "TEST-1000"
 
 


### PR DESCRIPTION
- Add logic to handle assignee resolution for Jira Cloud by checking
  if Jira instance is cloud-based using `_is_cloud`.
- Implement `_resolve_assignee` method to convert an assignee string
  into the correct Jira field format based on the server type.
- Update methods that assign Jira issues to use `_resolve_assignee`.
- Modify tests to validate changes in assignee resolution for cloud.
