### PR TITLE
Refactor Jira ticket counting and add API tool

### DIFF
--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -639,6 +639,23 @@ class JiraService:
         except Exception as e:
             raise Exception(f"Error searching tickets: {str(e)}") from e
 
+    def count_tickets(self, jql: str) -> int:
+        """Count tickets matching a JQL query.
+
+        On Jira Cloud uses the approximate-count endpoint.
+        On Jira Server/DC uses a minimal search with maxResults=0.
+        """
+        if self._is_cloud:
+            resp = self.jira._session.post(
+                f"{self.jira_url}/rest/api/3/search/approximate-count",
+                json={"jql": jql},
+            )
+            resp.raise_for_status()
+            return resp.json().get("count", 0)
+
+        issues = self.jira.search_issues(jql, maxResults=0)
+        return issues.total
+
     def _search_all(self, jql: str, fields: str) -> list[Any]:
         """Search Jira and auto-paginate to collect all results."""
         all_issues: list[Any] = []

--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -253,6 +253,7 @@ class JiraService:
                     if issue.fields.versions
                     else []
                 ),
+                "parent": self._get_parent(issue),
                 "total_comments": total_comments,
                 "url": f"{self.jira_url}/browse/{issue.key}",
             }
@@ -280,6 +281,8 @@ class JiraService:
                 "fixVersions",
                 "versions",
                 "comment",
+                "parent",
+                "issuelinks",
             }
             custom_fields = {}
             custom_field_ids = {}
@@ -303,6 +306,12 @@ class JiraService:
             if custom_field_ids:
                 ticket_data["custom_field_ids"] = custom_field_ids
 
+            # Get web links (remote links)
+            ticket_data["web_links"] = self._get_web_links(ticket_key)
+
+            # Get issue links (linked Jira tickets)
+            ticket_data["issue_links"] = self._get_issue_links(issue)
+
             # Get comments
             comments = self._get_comments(issue, max_comments, comment_offset)
             ticket_data["comments"] = comments
@@ -310,6 +319,11 @@ class JiraService:
             # Get changelog/history
             changelog = self._get_changelog(issue)
             ticket_data["changelog"] = changelog
+
+            # Get remote links (web links)
+            remote_links = self._get_remote_links(ticket_key)
+            if remote_links:
+                ticket_data["remote_links"] = remote_links
 
             return ticket_data
 
@@ -340,6 +354,30 @@ class JiraService:
 
         return comments
 
+    def _get_remote_links(self, ticket_key: str) -> list[dict[str, Any]]:
+        """Fetch remote links (web links) for an issue."""
+        try:
+            links = self.jira.remote_links(ticket_key)
+            result = []
+            for link in links:
+                link_obj = getattr(link, "object", None) or {}
+                if isinstance(link_obj, dict):
+                    url = link_obj.get("url")
+                    title = link_obj.get("title")
+                else:
+                    url = getattr(link_obj, "url", None)
+                    title = getattr(link_obj, "title", None)
+                result.append(
+                    {
+                        "id": getattr(link, "id", None),
+                        "url": url,
+                        "title": title,
+                    }
+                )
+            return result
+        except Exception:
+            return []
+
     def _get_changelog(self, issue: Any) -> list[dict[str, Any]]:
         """Extract changelog/history from the issue."""
         changelog = []
@@ -369,6 +407,62 @@ class JiraService:
                 changelog.append(history_data)
 
         return changelog
+
+    def _get_parent(self, issue: Any) -> dict[str, str | None] | None:
+        """Extract parent ticket info (Epic, Story, etc.)."""
+        parent = getattr(issue.fields, "parent", None)
+        if parent is None:
+            return None
+        return {
+            "key": parent.key,
+            "summary": getattr(parent.fields, "summary", None),
+            "issue_type": (
+                getattr(parent.fields.issuetype, "name", None)
+                if getattr(parent.fields, "issuetype", None)
+                else None
+            ),
+        }
+
+    def _get_web_links(self, ticket_key: str) -> list[dict[str, str]]:
+        """Fetch remote (web) links for an issue."""
+        try:
+            remote_links = self.jira.remote_links(ticket_key)
+            return [
+                {
+                    "url": link.object.url,
+                    "title": getattr(link.object, "title", link.object.url),
+                }
+                for link in remote_links
+                if hasattr(link, "object") and hasattr(link.object, "url")
+            ]
+        except Exception:
+            return []
+
+    def _get_issue_links(self, issue: Any) -> list[dict[str, str | None]]:
+        """Extract issue links (linked Jira tickets) from an issue."""
+        links: list[dict[str, str | None]] = []
+        issue_links = getattr(issue.fields, "issuelinks", None)
+        if not issue_links:
+            return links
+        for link in issue_links:
+            link_type = getattr(link.type, "name", "Related")
+            if hasattr(link, "outwardIssue"):
+                target = link.outwardIssue
+                direction = getattr(link.type, "outward", link_type)
+            elif hasattr(link, "inwardIssue"):
+                target = link.inwardIssue
+                direction = getattr(link.type, "inward", link_type)
+            else:
+                continue
+            links.append(
+                {
+                    "key": target.key,
+                    "summary": getattr(target.fields, "summary", None),
+                    "direction": direction,
+                    "link_type": link_type,
+                }
+            )
+        return links
 
     def _get_status_name_map(self) -> dict[str, str]:
         """Fetch status ID → English name map from Jira REST API v3.
@@ -555,6 +649,24 @@ class JiraService:
             raise Exception(f"Jira API error: {e.text}") from e
         except Exception as e:
             raise Exception(f"Error adding comment to {ticket_key}: {str(e)}") from e
+
+    def add_weblink(self, ticket_key: str, url: str, title: str) -> dict[str, Any]:
+        """Add a web link (remote link) to a Jira issue.
+
+        Returns:
+            Dictionary with link ID and URL
+        """
+        try:
+            link = self.jira.add_simple_link(ticket_key, {"url": url, "title": title})
+            return {
+                "link_id": link.id if hasattr(link, "id") else str(link),
+                "url": url,
+                "title": title,
+            }
+        except JIRAError as e:
+            raise Exception(f"Jira API error: {e.text}") from e
+        except Exception as e:
+            raise Exception(f"Error adding web link to {ticket_key}: {str(e)}") from e
 
     def get_transitions(self, ticket_key: str) -> list[dict[str, Any]]:
         """

--- a/mcp_server/tools/jira_tools.py
+++ b/mcp_server/tools/jira_tools.py
@@ -105,11 +105,15 @@ def register_jira_tools(mcp: FastMCP) -> None:
         - **People**: assignee, reporter
         - **Dates**: created, updated
         - **Classification**: labels, components, fix_versions, affected_versions
+        - **Parent**: parent ticket (key, summary, issue_type) or null
         - **Custom Fields**: custom_fields dict with human-readable field names as keys
           (only non-null custom fields are included)
         - **Custom Field IDs**: custom_field_ids dict mapping field names to their
           customfield_NNNNN IDs (use these IDs or names with update_jira_ticket's
           custom_fields parameter to update values)
+        - **Web Links**: web_links list with url and title for each remote link
+        - **Issue Links**: issue_links list with key, summary, direction, link_type
+          for each linked Jira ticket
         - **total_comments**: Total number of comments on the ticket
         - **Comments**: Comments with author, body, timestamps (paginated)
         - **Changelog**: History of changes with field modifications

--- a/mcp_server/tools/jira_tools.py
+++ b/mcp_server/tools/jira_tools.py
@@ -233,6 +233,40 @@ def register_jira_tools(mcp: FastMCP) -> None:
             return json.dumps({"error": str(e)}, indent=2)
 
     @mcp.tool()
+    async def count_jira_tickets(
+        jql: Annotated[
+            str,
+            Field(
+                description="JQL (Jira Query Language) query string. Examples: 'project = CILAB AND status = Open', 'assignee = currentUser() AND status != Closed'"
+            ),
+        ],
+    ) -> str:
+        """Count Jira tickets matching a JQL query.
+
+        Returns the total number of tickets matching the query without
+        fetching ticket data. Use this instead of search_jira_tickets
+        when you only need the count.
+
+        ## Authentication Required
+
+        Requires `JIRA_API_TOKEN` environment variable.
+
+        ## Returned Data
+
+        Returns a JSON object with:
+        - **count**: Total number of matching tickets
+
+        Returns:
+            JSON string with count
+        """
+        try:
+            jira_service = JiraService()
+            count = jira_service.count_tickets(jql)
+            return json.dumps({"count": count})
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool()
     async def get_jira_project_info(
         project_key: Annotated[
             str,

--- a/mcp_server/tools/jira_write_tools.py
+++ b/mcp_server/tools/jira_write_tools.py
@@ -254,6 +254,51 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
             return json.dumps({"error": str(e)}, indent=2)
 
     @mcp.tool()
+    async def add_jira_weblink(
+        ticket_key: Annotated[
+            str,
+            Field(
+                description="Jira ticket key in format PROJECT-NUMBER (e.g., CILAB-1234)"
+            ),
+        ],
+        url: Annotated[
+            str,
+            Field(description="URL to link to"),
+        ],
+        title: Annotated[
+            str,
+            Field(description="Display title for the link"),
+        ],
+    ) -> str:
+        """Add a web link to a Jira ticket.
+
+        Adds a remote/web link visible in the ticket's link section.
+
+        ## Authentication Required
+
+        Requires `JIRA_API_TOKEN` and `JIRA_WRITE_ENABLED=true` environment variables.
+
+        ## Returned Data
+
+        Returns a JSON object with:
+        - **link_id**: ID of the created link
+        - **url**: The linked URL
+        - **title**: Display title of the link
+
+        Returns:
+            JSON string with link data
+        """
+        try:
+            normalized_key = validate_ticket_key(ticket_key)
+            jira_service = JiraService()
+            result = jira_service.add_weblink(normalized_key, url, title)
+            return json.dumps(result, indent=2)
+        except ValueError as e:
+            return json.dumps({"error": str(e)}, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
     async def list_jira_custom_field_options(
         ticket_key: Annotated[
             str,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -211,6 +211,7 @@ EVAL_CASES = [
         "allowed_tools": [
             "mcp__dci__search_jira_tickets",
             "mcp__dci__get_jira_ticket",
+            "mcp__dci__count_jira_tickets",
         ],
         "expected_tools": ["mcp__dci__search_jira_tickets"],
         "expected_params": {"jql": "CILAB"},

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -779,6 +779,122 @@ def test_add_comment():
     assert result["created"] == "2025-01-01T00:00:00Z"
 
 
+# -- add_weblink tests --
+
+
+def test_add_weblink():
+    svc = _make_jira_service()
+    mock_link = MagicMock()
+    mock_link.id = "99"
+    svc.jira.add_simple_link.return_value = mock_link
+
+    result = svc.add_weblink("TEST-123", "https://example.com", "Example Link")
+
+    svc.jira.add_simple_link.assert_called_once_with(
+        "TEST-123", {"url": "https://example.com", "title": "Example Link"}
+    )
+    assert result["link_id"] == "99"
+    assert result["url"] == "https://example.com"
+    assert result["title"] == "Example Link"
+
+
+# -- _get_parent tests --
+
+
+def test_get_parent():
+    svc = _make_jira_service()
+    issue = MagicMock()
+    issue.fields.parent.key = "EPIC-1"
+    issue.fields.parent.fields.summary = "Parent epic"
+    issue.fields.parent.fields.issuetype.name = "Epic"
+
+    result = svc._get_parent(issue)
+
+    assert result == {
+        "key": "EPIC-1",
+        "summary": "Parent epic",
+        "issue_type": "Epic",
+    }
+
+
+def test_get_parent_none():
+    svc = _make_jira_service()
+    issue = MagicMock()
+    issue.fields.parent = None
+
+    result = svc._get_parent(issue)
+
+    assert result is None
+
+
+# -- _get_web_links / _get_issue_links tests --
+
+
+def test_get_web_links():
+    svc = _make_jira_service()
+    link1 = MagicMock()
+    link1.object.url = "https://example.com"
+    link1.object.title = "Example"
+    link2 = MagicMock()
+    link2.object.url = "https://other.com"
+    link2.object.title = "Other"
+    svc.jira.remote_links.return_value = [link1, link2]
+
+    result = svc._get_web_links("TEST-123")
+
+    assert len(result) == 2
+    assert result[0] == {"url": "https://example.com", "title": "Example"}
+    assert result[1] == {"url": "https://other.com", "title": "Other"}
+
+
+def test_get_web_links_empty():
+    svc = _make_jira_service()
+    svc.jira.remote_links.return_value = []
+
+    result = svc._get_web_links("TEST-123")
+
+    assert result == []
+
+
+def test_get_issue_links():
+    svc = _make_jira_service()
+    issue = MagicMock()
+
+    outward_link = MagicMock()
+    outward_link.type.name = "Blocks"
+    outward_link.type.outward = "blocks"
+    outward_link.outwardIssue.key = "TEST-456"
+    outward_link.outwardIssue.fields.summary = "Blocked ticket"
+    del outward_link.inwardIssue
+
+    inward_link = MagicMock()
+    inward_link.type.name = "Blocks"
+    inward_link.type.inward = "is blocked by"
+    inward_link.inwardIssue.key = "TEST-789"
+    inward_link.inwardIssue.fields.summary = "Blocking ticket"
+    del inward_link.outwardIssue
+
+    issue.fields.issuelinks = [outward_link, inward_link]
+
+    result = svc._get_issue_links(issue)
+
+    assert len(result) == 2
+    assert result[0]["key"] == "TEST-456"
+    assert result[0]["direction"] == "blocks"
+    assert result[1]["key"] == "TEST-789"
+    assert result[1]["direction"] == "is blocked by"
+
+
+def test_get_issue_links_empty():
+    svc = _make_jira_service()
+    issue = MagicMock()
+    issue.fields.issuelinks = []
+
+    result = svc._get_issue_links(issue)
+
+    assert result == []
+
+
 # -- get_transitions tests --
 
 

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -465,6 +465,46 @@ def test_search_tickets_with_offset():
     )
 
 
+# -- count_tickets tests --
+
+
+@pytest.mark.unit
+def test_count_tickets_cloud():
+    """On Jira Cloud, count_tickets uses the approximate-count endpoint."""
+    svc = _make_jira_service()
+    svc._is_cloud = True
+    svc.jira_url = "https://example.atlassian.net"
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"count": 1234}
+    mock_resp.raise_for_status = MagicMock()
+    svc.jira._session.post = MagicMock(return_value=mock_resp)
+
+    result = svc.count_tickets("project = TEST")
+
+    assert result == 1234
+    svc.jira._session.post.assert_called_once_with(
+        "https://example.atlassian.net/rest/api/3/search/approximate-count",
+        json={"jql": "project = TEST"},
+    )
+
+
+@pytest.mark.unit
+def test_count_tickets_server():
+    """On Jira Server/DC, count_tickets uses search_issues with maxResults=0."""
+    svc = _make_jira_service()
+    svc._is_cloud = False
+
+    mock_issues = MagicMock()
+    mock_issues.total = 500
+    svc.jira.search_issues.return_value = mock_issues
+
+    result = svc.count_tickets("project = TEST")
+
+    assert result == 500
+    svc.jira.search_issues.assert_called_once_with("project = TEST", maxResults=0)
+
+
 # -- _get_comments pagination tests --
 
 


### PR DESCRIPTION
- Simplify ticket count retrieval for both Jira Cloud and Server/DC
- Introduce count_tickets method to replace total count logic
- Add count_jira_tickets tool in jira_tools.py for API access
- Update tests for count_tickets to ensure accuracy
