### PR TITLE
Allow Jira cards to be unassigned

### DIFF
--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -56,12 +56,15 @@ class JiraService:
         self._status_name_map: dict[str, str] | None = None
         self._is_cloud = "atlassian.net" in self.jira_url
 
-    def _resolve_assignee(self, assignee: str) -> dict[str, str]:
+    def _resolve_assignee(self, assignee: str) -> dict[str, str] | None:
         """Resolve an assignee string to the correct Jira field format.
 
         Jira Cloud requires {"accountId": "..."} while Jira Server/DC
-        uses {"name": "..."}.
+        uses {"name": "..."}.  Pass an empty string or "none" to unassign.
         """
+        if assignee.strip().lower() in ("", "none", "unassigned"):
+            return None
+
         if not self._is_cloud:
             return {"name": assignee}
 

--- a/mcp_server/tools/jira_write_tools.py
+++ b/mcp_server/tools/jira_write_tools.py
@@ -126,7 +126,7 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
         assignee: Annotated[
             str | None,
             Field(
-                description="New assignee username (Jira Server/DC) or account ID (Jira Cloud)"
+                description='New assignee username (Jira Server/DC) or account ID (Jira Cloud). Use "none" to unassign'
             ),
         ] = None,
         transition: Annotated[

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -662,6 +662,24 @@ def test_update_issue_fields():
     assert result["status"] == "updated"
 
 
+@pytest.mark.parametrize("value", ["none", "None", "unassigned", "  none  ", ""])
+def test_update_issue_unassign(value):
+    svc = _make_jira_service()
+    mock_issue = MagicMock()
+    mock_issue.key = "TEST-123"
+    svc.jira.issue.return_value = mock_issue
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    svc.jira._session.put.return_value = mock_resp
+
+    result = svc.update_issue("TEST-123", assignee=value)
+
+    call_json = svc.jira._session.put.call_args[1]["json"]
+    assert call_json["fields"]["assignee"] is None
+    assert result["status"] == "updated"
+
+
 def test_update_issue_custom_fields():
     """Custom fields are resolved and rendered values returned."""
     svc = _make_jira_service()


### PR DESCRIPTION
When None is set as assignee the Jira card to be updated will be unassigned.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDYtMDNUMTY6NTQ6NTN8NTY1ZDVmZjRkYzNkM2FjNjE2NzQ4NzhiNGFjYWI4YTA1OTc4MzRhZA==
Gitleaks-Hash: 49ec55c7d599058e26c408bd73910d91b8fe5428881fc55efe09bb92e3cd13ec