### PR TITLE
feat: Make RCA prompt dynamic with job-aware file selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,10 +207,13 @@ bash scripts/run-checks.sh
 The server provides parameterized prompts for common DCI workflows:
 
 - **`/dci/rca <job_id>`**: Root Cause Analysis workflow
-  - Downloads and analyzes job files (ansible.log, logjuicer.txt, events.txt, must_gather)
-  - Stores files in `/tmp/dci/<job_id>/`
-  - Generates report at `/tmp/dci/rca-<job_id>.md`
-  - Includes timeline, components, topic, pipeline info, and Jira ticket validation
+  - **Dynamic prompt**: pre-fetches job metadata and file list from the DCI API to build a tailored prompt
+  - Classifies the job type from tags (acm > ztp > upgrade > day2 > sno > standard) and includes type-specific guidance
+  - Lists files grouped by investigation priority (ansible.log → logjuicer diffs → junit → must_gather → events → other logs → supporting)
+  - Filters out redundant files: TASK/PLAY/PLAYBOOK outputs (already in ansible.log), hardware/kernel data (in ES), DCI agent files, failed/skipped task files
+  - Paginates through the file API (jobs can have hundreds of files)
+  - Falls back to a static prompt if both metadata and file fetches fail
+  - Stores files in `/tmp/dci/<job_id>/`, generates report at `/tmp/dci/rca-<job_id>.md`
 
 - **`/dci/weekly <subject>`**: 7-day analysis for a team or remoteci
   - Generates report stored at `/tmp/dci/`
@@ -224,6 +227,16 @@ The server provides parameterized prompts for common DCI workflows:
   - Report stored at `/tmp/dci/<remoteci>/quarterly/<date-range>/report.md`
 
 Prompts are defined in `mcp_server/prompts/prompts.py` and registered via `register_prompts(mcp)`.
+
+### Prompt Rendering CLI
+
+Prompts can be rendered outside the MCP server for debugging and testing:
+
+- **List prompts**: `uv run python -m mcp_server.prompts --list`
+- **Render a prompt**: `uv run python -m mcp_server.prompts rca dci_job_id=<job-id>`
+- **Also available as**: `uv run dci-render-prompt rca dci_job_id=<job-id>`
+
+The library functions `render_prompt(name, **kwargs)` and `list_prompts()` in `mcp_server/prompts/render.py` are used by both the CLI and integration tests.
 
 ## Testing Guidelines
 
@@ -241,6 +254,15 @@ Eval tests (`tests/test_evals.py`) verify that Claude correctly selects and uses
 - Each eval case declares a `requires` field (`date`, `dci`, `jira`, `github`, `gitlab`, `support_case`). Cases are auto-skipped when credentials are missing from `.env`.
 - To add a new eval case, append to the `EVAL_CASES` list in `tests/test_evals.py` with: `id`, `prompt`, `requires`, `allowed_tools`, `expected_tools`, and optionally `expected_params` and `answer_contains`.
 - **When an eval fails with "Too many turns"**: This means the LLM retried because its first query failed — the tool description or examples are misleading. **Never** bump `max_turns` to work around the failure. Instead, reproduce the failure, capture the wrong query the LLM tried first, and fix the tool description (docstring, field description, or inline examples) so the LLM constructs the correct query on the first attempt.
+
+### Prompt Integration Tests
+
+Integration tests in `tests/test_rca_prompt_integration.py` verify the RCA prompt's dynamic section selection using **real DCI job IDs**. They call `render_prompt("rca", dci_job_id=<id>)` against the live DCI API and assert the correct job-type guidance appears.
+
+- Run: `uv run pytest tests/test_rca_prompt_integration.py -v`
+- Requires DCI credentials; auto-skipped when `DCI_CLIENT_ID`/`DCI_API_SECRET` are missing.
+- Each job type (ACM, ZTP, upgrade, day2, SNO, standard) has a dedicated test with a pinned job ID.
+- Use `uv run python -m mcp_server.prompts rca dci_job_id=<id>` to debug prompt output for a specific job.
 
 ## Commit & Pull Request Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,7 @@ bash scripts/run-checks.sh
 - Tool files: `mcp_server/tools/<domain>_tools.py` with `register_<domain>_tools(mcp)` function.
 - DCI services: `mcp_server/services/dci_<domain>_service.py` inheriting from `DCIBaseService`.
 - External services: `mcp_server/services/<service>_service.py` (e.g., `github_service.py`, `jira_service.py`).
+- New files must include the Apache 2.0 license header with `Copyright (C) <current-year> Red Hat, Inc.` (e.g., `Copyright (C) 2026 Red Hat, Inc.`). Do not use year ranges for new files.
 
 ## Prompts System
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,15 @@ Integration tests in `tests/test_rca_prompt_integration.py` verify the RCA promp
 - Each job type (ACM, ZTP, upgrade, day2, SNO, standard) has a dedicated test with a pinned job ID.
 - Use `uv run python -m mcp_server.prompts rca dci_job_id=<id>` to debug prompt output for a specific job.
 
+### RCA End-to-End Eval
+
+A full RCA evaluation runs Claude on a real DCI job, letting it download files, analyze logs, and produce a report. The test then validates the report contains expected sections and content.
+
+- Run: `uv run pytest -m rca_eval -v` or `bash scripts/run-checks.sh --rca-eval`
+- Expensive (~$1-2 per run, several minutes). Not included in the default `--test` target.
+- Requires DCI credentials and `claude` CLI.
+- Validates: report existence, expected sections (Root Cause, Recommendations), job links, must_gather usage, failure symptom.
+
 ## Commit & Pull Request Guidelines
 
 - Commit style observed: short, imperative, lowercase summaries (e.g., "fix authentication", "add /dci/rca prompt"). Keep scope clear and focused.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # DCI MCP Server - Change Log
 
+## [2026-06-07]
+
+### New Features
+
+- Add prompt rendering CLI (`python -m mcp_server.prompts` / `dci-render-prompt`) for debugging and inspecting MCP prompts outside the server
+- Add `render_prompt()` and `list_prompts()` library functions in `mcp_server/prompts/render.py`
+- Add integration tests for RCA prompt dynamic section selection using real DCI job IDs, verifying correct job-type guidance (ACM, ZTP, upgrade, day2, SNO, standard)
+
 ## [2026-05-06]
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -130,10 +130,26 @@ You can then use [prompts](PROMPTS.md) to explore the DCI data.
 
 There are also parameterized prompts defined in the MCP server:
 
-- `/dci/rca <job id>` conducts a Root Cause Analysis of the problem in the job. Storing the downloaded files under `/tmp/dci/<job id>` and generating a report at `/tmp/dci/rca-<job id>.md`.
+- `/dci/rca <job id>` conducts a Root Cause Analysis of a failing DCI job. The prompt is **dynamic**: it pre-fetches job metadata and files, classifies the job type (ACM, ZTP, upgrade, day2, SNO, or standard), and tailors the guidance and file priority list accordingly. Downloads files to `/tmp/dci/<job id>/` and generates a report at `/tmp/dci/rca-<job id>.md`.
 - `/dci/weekly <team name/id or remoteci name/id>` conducts a report for the last 7 days stored at `/tmp/dci`.
 - `/dci/biweekly <team name/id or remoteci name/id>` conducts a report for the last 14 days stored at `/tmp/dci`.
 - `/dci/quarterly <remoteci name/id>` conducts a comprehensive quarterly analysis (last 3 months) with statistics about pipelines, topics, failure rates, trends, and component usage. Uses pagination and caching to handle large datasets. Report stored at `/tmp/dci/<remoteci>/quarterly/<date-range>/report.md`.
+
+### Debugging Prompts
+
+You can render any prompt outside the MCP server for debugging:
+
+```bash
+# List available prompts
+uv run python -m mcp_server.prompts --list
+
+# Render a prompt with its parameters
+uv run python -m mcp_server.prompts rca dci_job_id=<job-id>
+uv run python -m mcp_server.prompts weekly subject=<team-name>
+
+# Also available as a standalone command
+uv run dci-render-prompt rca dci_job_id=<job-id>
+```
 
 ## Google Drive Integration
 
@@ -383,8 +399,10 @@ mcp_server/
 │   ├── jira_service.py
 │   ├── github_service.py
 │   └── support_case_service.py
-├── promps/               # Templatized prompts
-│   └── prompts.py
+├── prompts/              # Templatized prompts
+│   ├── prompts.py        # Prompt definitions and registration
+│   ├── render.py         # Render prompts outside MCP (library)
+│   └── __main__.py       # CLI: python -m mcp_server.prompts
 ├── tools/                # MCP tools
 │   ├── component_tools.py
 │   ├── date_tools.py

--- a/mcp_server/prompts/__init__.py
+++ b/mcp_server/prompts/__init__.py
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/mcp_server/prompts/__main__.py
+++ b/mcp_server/prompts/__main__.py
@@ -1,0 +1,77 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""CLI entry point for rendering MCP prompts.
+
+Usage::
+
+    python -m mcp_server.prompts --list
+    python -m mcp_server.prompts rca dci_job_id=<job-id>
+    python -m mcp_server.prompts weekly subject=test-team
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from .render import list_prompts, render_prompt
+
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        print("Usage: python -m mcp_server.prompts [--list] <name> [key=value ...]")
+        print()
+        print("Options:")
+        print("  --list    List available prompt names")
+        print()
+        print("Examples:")
+        print("  python -m mcp_server.prompts --list")
+        print("  python -m mcp_server.prompts rca dci_job_id=<job-id>")
+        print("  python -m mcp_server.prompts weekly subject=test-team")
+        sys.exit(0)
+
+    if args[0] == "--list":
+        for name in list_prompts():
+            print(name)
+        sys.exit(0)
+
+    name = args[0]
+    kwargs: dict[str, str] = {}
+    for arg in args[1:]:
+        if "=" not in arg:
+            print(
+                f"Error: argument {arg!r} must be in key=value format", file=sys.stderr
+            )
+            sys.exit(1)
+        key, value = arg.split("=", 1)
+        kwargs[key] = value
+
+    try:
+        result = asyncio.run(render_prompt(name, **kwargs))
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(result)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# __main__.py ends here

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -399,11 +399,18 @@ def _build_file_section(
         "install-config.yaml": "cluster install configuration",
         "agent-config.yaml": "agent-based installer configuration",
         "openshift_install.log": "openshift-install command output",
+        "openshift_install_state.json": "openshift-install internal state (terraform, cluster metadata)",
         "bootkube.log": "control-plane bootstrap logs",
         "ironic.log": "bare-metal provisioning (Ironic) logs",
         "ironic-inspector.log": "bare-metal hardware inspection logs",
         "ironic-ramdisk-logs.log": "bare-metal ramdisk (IPA) logs",
+        "image-customization.log": "RHCOS image customization logs",
+        "httpd.log": "bootstrap HTTP server logs (image serving)",
+        "coreos-downloader.log": "RHCOS image download logs",
+        "release-image.log": "OCP release image pull logs",
         "cluster-bootstrap.log": "cluster bootstrap progress logs",
+        "certsuite.log": "certsuite execution logs",
+        "certsuite-stdout.log": "certsuite stdout (version, test summary)",
         "claim.json": "certsuite test claim report",
     }
 
@@ -415,7 +422,12 @@ def _build_file_section(
             if name.startswith(prefix):
                 name = name[len(prefix) :]
                 break
-        return _file_descriptions.get(name, "")
+        desc = _file_descriptions.get(name, "")
+        if not desc and name.startswith("journal-") and name.endswith(".log"):
+            desc = (
+                "systemd journal for node — check for kernel, kubelet, or CRI-O errors"
+            )
+        return desc
 
     def _fmt(f: dict, annotation: str = "") -> str:
         size_kb = f.get("size", 0) / 1024

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -15,39 +15,17 @@
 
 """Prompts for the DCI MCP server."""
 
+import fnmatch
+import logging
 from typing import Annotated
 
+from ..services.dci_job_service import DCIJobService
 
-def register_prompts(mcp):
-    """Register prompts with the MCP server."""
+logger = logging.getLogger(__name__)
 
-    @mcp.prompt()
-    async def rca(
-        dci_job_id: Annotated[
-            str, "The DCI job ID for which to perform root cause analysis (RCA)."
-        ],
-    ) -> str:
-        """
-        Prompt for instructions on how to do a Root Cause Analysis (RCA) of a failing DCI job. Always use this prompt when analysing a failing DCI job.
-
-        Returns:
-            A prompt message with instructions on how to perform RCA of a failing DCI job.
-        """
-        return f"""Conduct a root cause analysis (RCA) on the following DCI job: {dci_job_id}. Store all the downloaded files at /tmp/dci/<job id>, so as not to download them twice. Create a report with your findings at /tmp/dci/rca-<job id>.md. Be sure to include details about the timeline of events and the DCI job information in the report, such as the components, the topic, and the pipeline name. If there is a CILAB-<num> comment, replace it with https://redhat.atlassian.net/browse/CILAB-<num>. Include a hyperlink in the form https://distributed-ci.io/jobs/<job id> each time you refer to the DCI job ID.
-
-## Step 1: Evidence Gathering
-
-First step is to review ansible.log (overview of the CI job execution). Then the logjuicer.txt (for regular files) and logjuicer_omg.txt (for must_gather) files that compare the logs from a previous successful run. For each difference flagged by logjuicer, determine whether it is a cause, a consequence, or unrelated to the failure.
-
-Later always download events.txt if it is available to understand the timeline.
-
-And lately, always validate your findings using the must_gather file and the omc utility if the must_gather file is available. Extract the must_gather file using the command: `tar -xf <must_gather_file>`. You can then use the omc utility to analyze the must_gather data using `omc use <extracted_must_gather_directory>`.
-
-Avoid looking at the DCI task files or failed_task.txt or play_recap, as they contain the same information as ansible.log.
-
-Do not hesitate to download any extra files that you think are relevant to the RCA.
-
-## Step 2: Root Cause Analysis using the 5 Whys Method
+# Shared RCA methodology text (Steps 2-4) used by both the static
+# fallback prompt and the dynamic prompt to avoid duplication.
+_RCA_METHODOLOGY = """## Step 2: Root Cause Analysis using the 5 Whys Method
 
 After gathering evidence, apply the "5 Whys" technique to drill down to the true root cause. Do not stop at the first error you find — that is usually a symptom, not the cause.
 
@@ -107,6 +85,430 @@ Structure the report with these sections:
 
 Check that the associated JIRA ticket is consistent with your findings.
 """
+
+
+def _fetch_job_metadata(job_id: str) -> dict | None:
+    """Fetch job metadata (tags, components, pipeline, status_reason).
+
+    Uses the DCI ES search API to retrieve a single job by ID with only
+    the fields needed for dynamic prompt generation.
+
+    Returns:
+        A dict with keys: tags, components, pipeline_name, status_reason,
+        status, topic_name.  Returns None on any failure.
+    """
+    try:
+        service = DCIJobService()
+        result = service.search_jobs(
+            query=f"(id='{job_id}')",
+            limit=1,
+            includes="id,tags,components.name,components.type,components.version,"
+            "pipeline.name,status_reason,status,topic.name",
+        )
+        hits = result.get("hits", {}).get("hits", [])
+        if not hits:
+            return None
+        src = hits[0].get("_source", hits[0])
+        return {
+            "tags": src.get("tags", []),
+            "components": src.get("components", []),
+            "pipeline_name": (src.get("pipeline") or {}).get("name", ""),
+            "status_reason": src.get("status_reason", ""),
+            "status": src.get("status", ""),
+            "topic_name": (src.get("topic") or {}).get("name", ""),
+        }
+    except Exception:
+        logger.debug("Failed to fetch metadata for job %s", job_id, exc_info=True)
+        return None
+
+
+def _fetch_job_files(job_id: str) -> list[dict] | None:
+    """Fetch the list of files attached to a job.
+
+    Calls the DCI API directly rather than through
+    ``DCIJobService.list_job_files()``, which swallows exceptions and
+    returns ``[]`` — making it impossible to distinguish *no files* from
+    *API failure*.
+
+    Returns:
+        A list of dicts with keys id, name, size.  Returns None on failure.
+    """
+    try:
+        from dciclient.v1.api import job as job_api
+
+        service = DCIJobService()
+        context = service._get_dci_context()
+        response = job_api.list_files(context, job_id)
+        data = response.json()
+        files_list = data.get("files", []) if isinstance(data, dict) else []
+        return [
+            {"id": f.get("id", ""), "name": f.get("name", ""), "size": f.get("size", 0)}
+            for f in files_list
+        ]
+    except Exception:
+        logger.debug("Failed to fetch files for job %s", job_id, exc_info=True)
+        return None
+
+
+def _classify_job_type(tags: list[str]) -> str:
+    """Classify the job type based on its tags.
+
+    Returns one of: "acm", "ztp", "upgrade", "day2", "sno", "standard".
+    The first matching rule wins (most-specific first).
+    """
+    tag_set = {t.lower() for t in tags}
+
+    if "install_type:acm" in tag_set:
+        return "acm"
+    if any("ztp" in t for t in tag_set):
+        return "ztp"
+    if any("upgrade" in t for t in tag_set):
+        return "upgrade"
+    if "agent:openshift-app" in tag_set or any("day2" in t for t in tag_set):
+        return "day2"
+    if any("sno" in t for t in tag_set) or "spoke" in tag_set:
+        return "sno"
+    return "standard"
+
+
+def _prioritize_files(
+    files: list[dict],
+) -> dict[str, list[dict]]:
+    """Categorize files into priority buckets for the RCA prompt.
+
+    Priority buckets (P1 = most important):
+      P1 – ansible.log
+      P2 – logjuicer*.txt  (excluding logjuicer_omg*)
+      P3 – logjuicer_omg*.txt
+      P4 – *junit*
+      P5 – *must_gather*.tar.gz
+      P6 – *events.txt
+      P7 – other *.log files
+      P8 – supporting (everything else)
+
+    Files matching skip patterns (failed_task.txt, play_recap, DCI task
+    files) are excluded entirely.
+    """
+    skip_patterns = ["failed_task.txt", "play_recap", "task_*"]
+    buckets: dict[str, list[dict]] = {
+        "P1": [],
+        "P2": [],
+        "P3": [],
+        "P4": [],
+        "P5": [],
+        "P6": [],
+        "P7": [],
+        "P8": [],
+    }
+
+    for f in files:
+        name = f.get("name", "")
+        if any(fnmatch.fnmatch(name, pat) for pat in skip_patterns):
+            continue
+
+        if name == "ansible.log":
+            buckets["P1"].append(f)
+        elif fnmatch.fnmatch(name, "logjuicer_omg*"):
+            buckets["P3"].append(f)
+        elif fnmatch.fnmatch(name, "logjuicer*"):
+            buckets["P2"].append(f)
+        elif fnmatch.fnmatch(name, "*junit*"):
+            buckets["P4"].append(f)
+        elif fnmatch.fnmatch(name, "*must_gather*"):
+            buckets["P5"].append(f)
+        elif fnmatch.fnmatch(name, "*events.txt"):
+            buckets["P6"].append(f)
+        elif fnmatch.fnmatch(name, "*.log"):
+            buckets["P7"].append(f)
+        else:
+            buckets["P8"].append(f)
+
+    return buckets
+
+
+def _build_job_type_guidance(job_type: str, components: list[dict]) -> str:
+    """Return job-type-specific RCA guidance text.
+
+    Args:
+        job_type: one of the values returned by _classify_job_type().
+        components: list of component dicts (name, type, version).
+
+    Returns:
+        A markdown section string, or empty string for 'standard' jobs.
+    """
+    if job_type == "acm":
+        return """
+## Job-Type Guidance: ACM (Advanced Cluster Management)
+
+This is an ACM-managed deployment with a **hub/spoke architecture**.
+- The **hub cluster** runs ACM and orchestrates spoke cluster provisioning.
+- **Spoke clusters** are the managed clusters deployed by ACM.
+
+Key ACM resources to check with `omc` or in must_gather:
+- **ManagedCluster** – registration and availability status of spoke clusters
+- **ClusterDeployment** – Hive cluster provisioning status
+- **AgentClusterInstall** – agent-based installation progress and conditions
+- **BareMetalHost** – hardware provisioning status (power, inspection, provisioning)
+- **InfraEnv** – discovery ISO and agent registration
+- Check ACM logs: `open-cluster-management-agent`, `assisted-service`, `infrastructure-operator`
+"""
+
+    if job_type == "ztp":
+        return """
+## Job-Type Guidance: ZTP (Zero Touch Provisioning)
+
+Key ZTP resources to check:
+- **SiteConfig / ClusterInstance** – declarative site definition and rendering status
+- **TALM (Topology Aware Lifecycle Manager)** – `ClusterGroupUpgrade` (CGU) status and conditions
+- **ArgoCD** – Application sync status, sync errors, out-of-sync resources
+- **PolicyGenTemplate / PolicyGenerator** – policy rendering and compliance status
+- Check that the Git repository content matches what ArgoCD applied.
+"""
+
+    if job_type == "upgrade":
+        # Extract version info from components if available
+        ocp_versions = [
+            c.get("version", c.get("name", ""))
+            for c in components
+            if c.get("type", "") == "ocp"
+        ]
+        version_note = ""
+        if ocp_versions:
+            version_note = (
+                f"\n- OCP component versions in this job: {', '.join(ocp_versions)}"
+            )
+        return f"""
+## Job-Type Guidance: Upgrade Pipeline
+
+This job is an **upgrade pipeline** — focus on the version transition.
+- Compare **before and after OCP versions** to identify known upgrade issues.{version_note}
+- Check **ClusterVersion** history: `oc get clusterversion version -o yaml`
+- Look for **degraded ClusterOperators** after the upgrade.
+- Check **MachineConfigPool** status — nodes may be stuck updating.
+- Review **etcd** health and leader election during the upgrade window.
+"""
+
+    if job_type == "day2":
+        return """
+## Job-Type Guidance: Day-2 Operation
+
+This job performs a **day-2 operation** (post-install workload or configuration).
+- Focus on the **specific operation being performed** (operator install, workload deploy, config change).
+- Check if the cluster was healthy *before* the day-2 operation started.
+- Look for resource conflicts, quota limits, or scheduling issues.
+- Review operator subscription and CSV (ClusterServiceVersion) status if an operator install is involved.
+"""
+
+    if job_type == "sno":
+        return """
+## Job-Type Guidance: SNO (Single Node OpenShift)
+
+This is a **Single Node OpenShift** deployment.
+- All control-plane and worker workloads run on one node — resource exhaustion is common.
+- Check node resource usage: CPU, memory, disk pressure conditions.
+- SNO has no failover — any node issue means total cluster unavailability.
+- Check if the node was rebooted unexpectedly during the job.
+"""
+
+    return ""
+
+
+def _build_file_section(buckets: dict[str, list[dict]]) -> str:
+    """Build the file inventory section of the RCA prompt.
+
+    Lists files grouped by priority with download instructions referencing
+    actual file IDs.
+    """
+    lines = ["## Available Files\n"]
+    lines.append(
+        "Below are the files attached to this job, organized by investigation "
+        "priority. Use the **file ID** to download each file.\n"
+    )
+
+    def _fmt(f: dict) -> str:
+        size_kb = f.get("size", 0) / 1024
+        if size_kb > 1024:
+            size_str = f"{size_kb / 1024:.1f} MB"
+        else:
+            size_str = f"{size_kb:.0f} KB"
+        return f"  - `{f['name']}` (id: `{f['id']}`, {size_str})"
+
+    bucket_labels = {
+        "P1": (
+            "### P1 — Entry Point: ansible.log",
+            "Start here. Use `status_reason` (shown above) to jump to the "
+            "failure point in the Ansible run.",
+        ),
+        "P2": (
+            "### P2 — Logjuicer diffs (Ansible logs)",
+            "Diffs comparing this job's Ansible logs against the last successful "
+            "run. Identify what changed.",
+        ),
+        "P3": (
+            "### P3 — Logjuicer diffs (must_gather)",
+            "Diffs comparing must_gather output against the last successful run. "
+            "Each file corresponds to a different must_gather archive.",
+        ),
+        "P4": (
+            "### P4 — Test results (JUnit)",
+            "Test result summaries. Check which tests failed and their error messages.",
+        ),
+        "P5": (
+            "### P5 — must_gather archives",
+            "Cluster state snapshots. Extract with `tar -xf <file>` and inspect "
+            "with `omc use <extracted_dir>`.",
+        ),
+        "P6": (
+            "### P6 — Event logs",
+            "Kubernetes events timeline. Use to verify causal ordering.",
+        ),
+        "P7": (
+            "### P7 — Other log files",
+            "Additional log files that may contain relevant clues.",
+        ),
+        "P8": (
+            "### P8 — Supporting files",
+            "Other files attached to the job. Download if needed for deeper "
+            "investigation.",
+        ),
+    }
+
+    any_files = False
+    for bucket_key in ("P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"):
+        bucket_files = buckets.get(bucket_key, [])
+        if not bucket_files:
+            continue
+        any_files = True
+        title, description = bucket_labels[bucket_key]
+        lines.append(f"\n{title}\n")
+        lines.append(f"{description}\n")
+        for f in bucket_files:
+            lines.append(_fmt(f))
+
+    if not any_files:
+        lines.append("\n_No files found on this job._\n")
+
+    return "\n".join(lines)
+
+
+def _static_rca_prompt(dci_job_id: str) -> str:
+    """Return the static fallback RCA prompt when pre-fetching fails."""
+    return f"""Conduct a root cause analysis (RCA) on the following DCI job: {dci_job_id}. Store all the downloaded files at /tmp/dci/{dci_job_id}/, so as not to download them twice. Create a report with your findings at /tmp/dci/rca-{dci_job_id}.md. Be sure to include details about the timeline of events and the DCI job information in the report, such as the components, the topic, and the pipeline name. If there is a CILAB-<num> comment, replace it with https://redhat.atlassian.net/browse/CILAB-<num>. Include a hyperlink in the form https://distributed-ci.io/jobs/<job id> each time you refer to the DCI job ID.
+
+## Step 1: Evidence Gathering
+
+First step is to review ansible.log (overview of the CI job execution). Then the logjuicer.txt (for regular files) and logjuicer_omg.txt (for must_gather) files that compare the logs from a previous successful run. For each difference flagged by logjuicer, determine whether it is a cause, a consequence, or unrelated to the failure.
+
+Later always download events.txt if it is available to understand the timeline.
+
+And lately, always validate your findings using the must_gather file and the omc utility if the must_gather file is available. Extract the must_gather file using the command: `tar -xf <must_gather_file>`. You can then use the omc utility to analyze the must_gather data using `omc use <extracted_must_gather_directory>`.
+
+Avoid looking at the DCI task files or failed_task.txt or play_recap, as they contain the same information as ansible.log.
+
+Do not hesitate to download any extra files that you think are relevant to the RCA.
+
+{_RCA_METHODOLOGY}"""
+
+
+def register_prompts(mcp):
+    """Register prompts with the MCP server."""
+
+    @mcp.prompt()
+    async def rca(
+        dci_job_id: Annotated[
+            str, "The DCI job ID for which to perform root cause analysis (RCA)."
+        ],
+    ) -> str:
+        """
+        Prompt for instructions on how to do a Root Cause Analysis (RCA) of a failing DCI job. Always use this prompt when analysing a failing DCI job.
+
+        Returns:
+            A prompt message with instructions on how to perform RCA of a failing DCI job.
+        """
+        # -- Pre-fetch job metadata and files ----------------------------------
+        metadata = _fetch_job_metadata(dci_job_id)
+        files = _fetch_job_files(dci_job_id)
+
+        # If both fetches fail, fall back to the static prompt so the agent
+        # can still do its job (just without the dynamic file list).
+        if metadata is None and files is None:
+            return _static_rca_prompt(dci_job_id)
+
+        # -- Build dynamic prompt sections -------------------------------------
+        tags = (metadata or {}).get("tags", [])
+        components = (metadata or {}).get("components", [])
+        pipeline_name = (metadata or {}).get("pipeline_name", "unknown")
+        status_reason = (metadata or {}).get("status_reason", "")
+        status = (metadata or {}).get("status", "unknown")
+        topic_name = (metadata or {}).get("topic_name", "unknown")
+
+        job_type = _classify_job_type(tags)
+
+        # -- Job context header ------------------------------------------------
+        comp_summary = ", ".join(
+            f"{c.get('type', '?')}:{c.get('name', c.get('version', '?'))}"
+            for c in components
+        )
+
+        job_context = f"""## Job Context
+
+| Field | Value |
+|-------|-------|
+| **Job ID** | [{dci_job_id}](https://distributed-ci.io/jobs/{dci_job_id}) |
+| **Status** | {status} |
+| **Pipeline** | {pipeline_name} |
+| **Topic** | {topic_name} |
+| **Job type** | {job_type} |
+| **Tags** | {", ".join(tags) if tags else "none"} |
+| **Components** | {comp_summary or "none"} |
+"""
+        if status_reason:
+            job_context += f"""
+**Status reason** (use this to locate the failure point in ansible.log):
+```
+{status_reason}
+```
+"""
+
+        # -- File inventory section --------------------------------------------
+        if files is not None:
+            buckets = _prioritize_files(files)
+            file_section = _build_file_section(buckets)
+        else:
+            file_section = (
+                "## Available Files\n\n"
+                "_File list could not be pre-fetched. "
+                "Use the `search_dci_jobs` or file listing tools to discover "
+                "available files for this job._\n"
+            )
+
+        # -- Job-type guidance -------------------------------------------------
+        type_guidance = _build_job_type_guidance(job_type, components)
+
+        # -- Assemble full prompt ----------------------------------------------
+        return f"""Conduct a root cause analysis (RCA) on DCI job [{dci_job_id}](https://distributed-ci.io/jobs/{dci_job_id}).
+
+Store all downloaded files at `/tmp/dci/{dci_job_id}/` to avoid re-downloading.
+Create a report at `/tmp/dci/rca-{dci_job_id}.md`.
+If there is a CILAB-<num> comment, replace it with `https://redhat.atlassian.net/browse/CILAB-<num>`.
+
+{job_context}
+{file_section}
+{type_guidance}
+## Step 1: Evidence Gathering
+
+Follow the prioritized file list above. For each file:
+1. Download it using its **file ID** (provided above).
+2. Analyze it according to its role described in the file list.
+3. For each difference flagged by logjuicer files, determine whether it is a **cause**, a **consequence**, or **unrelated** to the failure.
+
+If must_gather files are available, extract them with `tar -xf <file>` and use `omc use <extracted_dir>` to inspect cluster state.
+
+**Avoid** looking at DCI task files, `failed_task.txt`, or `play_recap` — they duplicate ansible.log content.
+
+Do not hesitate to download any extra files from the "Other files" or "Supporting files" sections that may be relevant.
+
+{_RCA_METHODOLOGY}"""
 
     @mcp.prompt()
     async def weekly(

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -40,6 +40,16 @@ After gathering evidence, apply the "5 Whys" technique to drill down to the true
 
 At each level, cite the specific log file and relevant log lines as evidence.
 
+**Self-check**: After writing the causal chain, fill in this table in your report:
+
+| Level | Claim | Evidence (file + line/content) | Type |
+|-------|-------|-------------------------------|------|
+| Why 1 | ... | `ansible.log` line 1234: "error msg" | Direct |
+| Why 2 | ... | `events.txt`: Pod evicted at 10:23 | Direct |
+| ... | ... | ... | Direct or Inferred |
+
+If any level is "Inferred" (no direct log evidence), explicitly state what evidence is missing and what you searched for.
+
 ### Categorize potential causes
 
 Before narrowing down, consider causes across these categories to avoid tunnel vision:
@@ -55,7 +65,11 @@ Before finalizing your root cause, actively try to DISPROVE it:
 
 1. **Generate an alternative hypothesis** from a DIFFERENT category than your root cause. If your root cause is "Software Bug," propose an Infrastructure or Timing explanation that fits the same evidence. If it's "Infrastructure," propose a Configuration explanation.
 
-2. **Find evidence that supports the alternative** — look in the logs for anything consistent with the alternative and inconsistent with your primary hypothesis.
+2. **Actively search for evidence** — do NOT just reason about the alternative. For each alternative hypothesis, you MUST:
+   - Identify what evidence would support it (e.g., "if it were a network issue, I'd expect to see connection timeouts in events.txt")
+   - Actually search for that evidence in the downloaded files
+   - Report what you found or didn't find, with specific file references
+   - Only then conclude whether the alternative is supported or refuted
 
 3. **Apply the counterfactual test to BOTH hypotheses**:
    - If root cause A had been absent, would the job have succeeded?
@@ -601,9 +615,14 @@ You MUST download and inspect ALL must_gather archives listed above. Do NOT skip
 1. Download each must_gather archive using its file ID.
 2. Extract it: `tar -xf <file>`
 3. Inspect with: `omc use <extracted_dir>`
-4. Use `omc` to check cluster state: nodes, pods, operators, events, and any resources relevant to the failure.
+4. Use `omc` to investigate cluster state as **primary evidence** in your causal chain, not just for verification. Check:
+   - Node conditions and resource usage (`omc get nodes -o wide`, `omc describe node`)
+   - Pod status across namespaces (`omc get pods -A`, focus on failing/pending/evicted pods)
+   - ClusterOperator health (`omc get co`)
+   - Any resources specific to the failure mode (see job-type guidance above)
+5. Integrate must_gather findings directly into your 5 Whys causal chain — cite `omc` output as evidence alongside log files.
 
-Your root cause analysis is incomplete without must_gather validation. If your findings from ansible.log and logjuicer are not confirmed by must_gather data, state that explicitly.
+must_gather captures cluster state at a point in time. Use it to find evidence that **supports or refutes** your hypotheses, not just to confirm what the logs already told you.
 """
         else:
             must_gather_instructions = ""

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -169,7 +169,12 @@ def _fetch_job_files(job_id: str) -> list[dict] | None:
             offset += limit
 
         return [
-            {"id": f.get("id", ""), "name": f.get("name", ""), "size": f.get("size", 0)}
+            {
+                "id": f.get("id", ""),
+                "name": f.get("name", ""),
+                "size": f.get("size", 0),
+                "mime": f.get("mime", ""),
+            }
             for f in all_files
         ]
     except Exception:
@@ -203,34 +208,29 @@ def _prioritize_files(
 ) -> dict[str, list[dict]]:
     """Categorize files into priority buckets for the RCA prompt.
 
+    Classification uses MIME types first, then falls back to name patterns:
+      - ``application/x-ansible-output`` → skipped (duplicates ansible.log)
+      - ``application/junit`` → P4 (test results)
+      - ``application/x-gzip`` with ``*must_gather*`` → P5
+
     Priority buckets (P1 = most important):
       P1 – ansible.log
       P2 – logjuicer*.txt  (excluding logjuicer_omg*)
       P3 – logjuicer_omg*.txt
-      P4 – *junit*
+      P4 – application/junit files
       P5 – *must_gather*.tar.gz
       P6 – *events.txt
       P6b – *-console.log (bare-metal node console output)
       P7 – other *.log files
       P8 – supporting (everything else)
 
-    Files matching skip patterns (failed_task.txt, play_recap, DCI task
-    files) are excluded entirely.
+    Files matching skip patterns or MIME-based skips are excluded entirely.
     """
+    skip_mime_types = {"application/x-ansible-output"}
     skip_patterns = [
         "failed_task.txt",
         "play_recap",
         "task_*",
-        "TASK *",
-        "TASK [*",
-        "*/TASK *",
-        "*/TASK [*",
-        "*/PLAY RECAP",
-        "PLAY *",
-        "PLAYBOOK*",
-        "failed/*",
-        "skipped/*",
-        "dci-openshift-*-agent",
         "hardware.*",
         "kernel.*",
     ]
@@ -248,7 +248,10 @@ def _prioritize_files(
 
     for f in files:
         name = f.get("name", "")
+        mime = f.get("mime", "")
         if f.get("size", 0) == 0:
+            continue
+        if mime in skip_mime_types:
             continue
         if any(fnmatch.fnmatch(name, pat) for pat in skip_patterns):
             continue
@@ -259,7 +262,7 @@ def _prioritize_files(
             buckets["P3"].append(f)
         elif fnmatch.fnmatch(name, "logjuicer*"):
             buckets["P2"].append(f)
-        elif fnmatch.fnmatch(name, "*junit*"):
+        elif mime == "application/junit":
             buckets["P4"].append(f)
         elif fnmatch.fnmatch(name, "*must_gather*"):
             buckets["P5"].append(f)
@@ -435,9 +438,11 @@ def _build_file_section(
             size_str = f"{size_kb / 1024:.1f} MB"
         else:
             size_str = f"{size_kb:.0f} KB"
+        mime = f.get("mime", "")
+        mime_str = f", {mime}" if mime else ""
         parts = [p for p in (annotation, _describe(f)) if p]
         suffix = f" — {'; '.join(parts)}" if parts else ""
-        return f"  - `{f['name']}` (id: `{f['id']}`, {size_str}){suffix}"
+        return f"  - `{f['name']}` (id: `{f['id']}`, {size_str}{mime_str}){suffix}"
 
     p1_description = (
         "Start here. Use `status_reason` (shown above) to jump to the "
@@ -452,8 +457,8 @@ def _build_file_section(
             p1_description,
         ),
         "P2": (
-            "Logjuicer diffs (Ansible logs)",
-            "Diffs comparing this job's Ansible logs against the last successful "
+            "Logjuicer diffs (non must_gather files)",
+            "Diffs comparing this job's files against the last successful "
             "run. Identify what changed.",
         ),
         "P3": (
@@ -462,8 +467,8 @@ def _build_file_section(
             "Each file corresponds to a different must_gather archive.",
         ),
         "P4": (
-            "Test results (JUnit)",
-            "Test result summaries. Check which tests failed and their error messages.",
+            "Test results (application/junit)",
+            "JUnit XML test results. Check which tests failed and their error messages.",
         ),
         "P5": (
             "must_gather archives",

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -82,8 +82,6 @@ Structure the report with these sections:
 5. **Contributing Factors**: conditions that enabled or worsened the failure
 6. **Confidence Level**: high, medium, or low — based on the strength of available evidence
 7. **Recommendations**: what should be done to prevent recurrence
-
-Check that the associated JIRA ticket is consistent with your findings.
 """
 
 
@@ -103,7 +101,7 @@ def _fetch_job_metadata(job_id: str) -> dict | None:
             query=f"(id='{job_id}')",
             limit=1,
             includes="id,tags,components.name,components.type,components.version,"
-            "pipeline.name,status_reason,status,topic.name",
+            "pipeline.name,status_reason,status,topic.name,comment",
         )
         hits = result.get("hits", {}).get("hits", [])
         if not hits:
@@ -116,6 +114,7 @@ def _fetch_job_metadata(job_id: str) -> dict | None:
             "status_reason": src.get("status_reason", ""),
             "status": src.get("status", ""),
             "topic_name": (src.get("topic") or {}).get("name", ""),
+            "comment": src.get("comment", ""),
         }
     except Exception:
         logger.debug("Failed to fetch metadata for job %s", job_id, exc_info=True)
@@ -130,6 +129,9 @@ def _fetch_job_files(job_id: str) -> list[dict] | None:
     returns ``[]`` — making it impossible to distinguish *no files* from
     *API failure*.
 
+    Paginates through the API (default page size is 20) to retrieve all
+    files.
+
     Returns:
         A list of dicts with keys id, name, size.  Returns None on failure.
     """
@@ -138,12 +140,23 @@ def _fetch_job_files(job_id: str) -> list[dict] | None:
 
         service = DCIJobService()
         context = service._get_dci_context()
-        response = job_api.list_files(context, job_id)
-        data = response.json()
-        files_list = data.get("files", []) if isinstance(data, dict) else []
+
+        all_files: list[dict] = []
+        limit = 200
+        offset = 0
+
+        while True:
+            response = job_api.list_files(context, job_id, limit=limit, offset=offset)
+            data = response.json()
+            files_page = data.get("files", []) if isinstance(data, dict) else []
+            all_files.extend(files_page)
+            if len(files_page) < limit:
+                break
+            offset += limit
+
         return [
             {"id": f.get("id", ""), "name": f.get("name", ""), "size": f.get("size", 0)}
-            for f in files_list
+            for f in all_files
         ]
     except Exception:
         logger.debug("Failed to fetch files for job %s", job_id, exc_info=True)
@@ -189,7 +202,23 @@ def _prioritize_files(
     Files matching skip patterns (failed_task.txt, play_recap, DCI task
     files) are excluded entirely.
     """
-    skip_patterns = ["failed_task.txt", "play_recap", "task_*"]
+    skip_patterns = [
+        "failed_task.txt",
+        "play_recap",
+        "task_*",
+        "TASK *",
+        "TASK [*",
+        "*/TASK *",
+        "*/TASK [*",
+        "*/PLAY RECAP",
+        "PLAY *",
+        "PLAYBOOK*",
+        "failed/*",
+        "skipped/*",
+        "dci-openshift-*-agent",
+        "hardware.*",
+        "kernel.*",
+    ]
     buckets: dict[str, list[dict]] = {
         "P1": [],
         "P2": [],
@@ -203,6 +232,8 @@ def _prioritize_files(
 
     for f in files:
         name = f.get("name", "")
+        if f.get("size", 0) == 0:
+            continue
         if any(fnmatch.fnmatch(name, pat) for pat in skip_patterns):
             continue
 
@@ -313,11 +344,17 @@ This is a **Single Node OpenShift** deployment.
     return ""
 
 
-def _build_file_section(buckets: dict[str, list[dict]]) -> str:
+def _build_file_section(
+    buckets: dict[str, list[dict]],
+    *,
+    status_reason: str = "",
+    job_type: str = "standard",
+) -> str:
     """Build the file inventory section of the RCA prompt.
 
     Lists files grouped by priority with download instructions referencing
-    actual file IDs.
+    actual file IDs.  Buckets are numbered sequentially (1, 2, 3, …) in
+    the output — only non-empty buckets appear.
     """
     lines = ["## Available Files\n"]
     lines.append(
@@ -325,67 +362,133 @@ def _build_file_section(buckets: dict[str, list[dict]]) -> str:
         "priority. Use the **file ID** to download each file.\n"
     )
 
-    def _fmt(f: dict) -> str:
+    # Descriptions for common supporting files to help the agent decide
+    # which ones are worth downloading.
+    _file_descriptions: dict[str, str] = {
+        "clusteroperator.txt": "ClusterOperator status — check for degraded operators",
+        "clusterversion.txt": "ClusterVersion — installed and target OCP version",
+        "nodes.txt": "node status summary (Ready/NotReady)",
+        "all-nodes.yaml": "full node objects with conditions and resources",
+        "pods.txt": "pod status across namespaces",
+        "operators.json": "installed OLM operators and subscriptions",
+        "clusternetwork.yaml": "cluster network configuration",
+        "machine-configs.txt": "MachineConfig and MachineConfigPool status",
+        "csr.txt": "pending certificate signing requests",
+        "pvc.txt": "PersistentVolumeClaim status",
+        "version.txt": "OCP version string",
+        "virtual-machines.txt": "KubeVirt VM status",
+        "image-sources.yaml": "image content source policies (mirrors)",
+        "install-config.yaml": "cluster install configuration",
+        "agent-config.yaml": "agent-based installer configuration",
+        "openshift_install.log": "openshift-install command output",
+        "claim.json": "certsuite test claim report",
+    }
+
+    def _describe(f: dict) -> str:
+        """Return a short description for a known file, or empty string."""
+        name = f.get("name", "")
+        # Strip spoke prefixes to match base name
+        for prefix in spoke_prefixes:
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+        return _file_descriptions.get(name, "")
+
+    def _fmt(f: dict, annotation: str = "") -> str:
         size_kb = f.get("size", 0) / 1024
         if size_kb > 1024:
             size_str = f"{size_kb / 1024:.1f} MB"
         else:
             size_str = f"{size_kb:.0f} KB"
-        return f"  - `{f['name']}` (id: `{f['id']}`, {size_str})"
+        parts = [p for p in (annotation, _describe(f)) if p]
+        suffix = f" — {'; '.join(parts)}" if parts else ""
+        return f"  - `{f['name']}` (id: `{f['id']}`, {size_str}){suffix}"
+
+    p1_description = (
+        "Start here. Use `status_reason` (shown above) to jump to the "
+        "failure point in the Ansible run."
+        if status_reason
+        else "Start here. Read through the Ansible run to find the failure point."
+    )
 
     bucket_labels = {
         "P1": (
-            "### P1 — Entry Point: ansible.log",
-            "Start here. Use `status_reason` (shown above) to jump to the "
-            "failure point in the Ansible run.",
+            "Entry Point: ansible.log",
+            p1_description,
         ),
         "P2": (
-            "### P2 — Logjuicer diffs (Ansible logs)",
+            "Logjuicer diffs (Ansible logs)",
             "Diffs comparing this job's Ansible logs against the last successful "
             "run. Identify what changed.",
         ),
         "P3": (
-            "### P3 — Logjuicer diffs (must_gather)",
+            "Logjuicer diffs (must_gather)",
             "Diffs comparing must_gather output against the last successful run. "
             "Each file corresponds to a different must_gather archive.",
         ),
         "P4": (
-            "### P4 — Test results (JUnit)",
+            "Test results (JUnit)",
             "Test result summaries. Check which tests failed and their error messages.",
         ),
         "P5": (
-            "### P5 — must_gather archives",
+            "must_gather archives",
             "Cluster state snapshots. Extract with `tar -xf <file>` and inspect "
             "with `omc use <extracted_dir>`.",
         ),
         "P6": (
-            "### P6 — Event logs",
+            "Event logs",
             "Kubernetes events timeline. Use to verify causal ordering.",
         ),
         "P7": (
-            "### P7 — Other log files",
+            "Other log files",
             "Additional log files that may contain relevant clues.",
         ),
         "P8": (
-            "### P8 — Supporting files",
+            "Supporting files",
             "Other files attached to the job. Download if needed for deeper "
             "investigation.",
         ),
     }
 
-    any_files = False
+    # Detect spoke prefixes from must_gather filenames in ACM jobs.
+    # e.g. "HighAvailable_must_gather.tar.gz" → prefix "HighAvailable_"
+    spoke_prefixes: list[str] = []
+    if job_type == "acm" and len(buckets.get("P5", [])) >= 2:
+        for f in buckets["P5"]:
+            name = f.get("name", "")
+            if name != "must_gather.tar.gz" and name.endswith("_must_gather.tar.gz"):
+                spoke_prefixes.append(name.removesuffix("must_gather.tar.gz"))
+
+    def _acm_annotation(f: dict, bucket_key: str) -> str:
+        if not spoke_prefixes or bucket_key == "P1":
+            return ""
+        name = f.get("name", "")
+        for prefix in spoke_prefixes:
+            if name.startswith(prefix):
+                return f"**spoke** cluster ({prefix.rstrip('_')})"
+        return "**hub** cluster"
+
+    seq = 0
     for bucket_key in ("P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"):
         bucket_files = buckets.get(bucket_key, [])
         if not bucket_files:
             continue
-        any_files = True
-        title, description = bucket_labels[bucket_key]
-        lines.append(f"\n{title}\n")
+        seq += 1
+        label, description = bucket_labels[bucket_key]
+        lines.append(f"\n### {seq}. {label}\n")
         lines.append(f"{description}\n")
         for f in bucket_files:
-            lines.append(_fmt(f))
+            lines.append(_fmt(f, _acm_annotation(f, bucket_key)))
 
-    if not any_files:
+    if spoke_prefixes:
+        lines.append(
+            "\n> **Note:** Files prefixed with "
+            + " or ".join(f"`{p}`" for p in spoke_prefixes)
+            + " belong to the **spoke** cluster. "
+            "Unprefixed files belong to the **hub** cluster.\n"
+        )
+
+    if seq == 0:
         lines.append("\n_No files found on this job._\n")
 
     return "\n".join(lines)
@@ -441,6 +544,7 @@ def register_prompts(mcp):
         status_reason = (metadata or {}).get("status_reason", "")
         status = (metadata or {}).get("status", "unknown")
         topic_name = (metadata or {}).get("topic_name", "unknown")
+        comment = (metadata or {}).get("comment", "")
 
         job_type = _classify_job_type(tags)
 
@@ -471,9 +575,13 @@ def register_prompts(mcp):
 """
 
         # -- File inventory section --------------------------------------------
+        has_must_gather = False
         if files is not None:
             buckets = _prioritize_files(files)
-            file_section = _build_file_section(buckets)
+            has_must_gather = bool(buckets.get("P5"))
+            file_section = _build_file_section(
+                buckets, status_reason=status_reason, job_type=job_type
+            )
         else:
             file_section = (
                 "## Available Files\n\n"
@@ -485,12 +593,36 @@ def register_prompts(mcp):
         # -- Job-type guidance -------------------------------------------------
         type_guidance = _build_job_type_guidance(job_type, components)
 
+        # -- must_gather instructions -------------------------------------------
+        if has_must_gather:
+            must_gather_instructions = """
+**MANDATORY — must_gather inspection:**
+You MUST download and inspect ALL must_gather archives listed above. Do NOT skip this step.
+1. Download each must_gather archive using its file ID.
+2. Extract it: `tar -xf <file>`
+3. Inspect with: `omc use <extracted_dir>`
+4. Use `omc` to check cluster state: nodes, pods, operators, events, and any resources relevant to the failure.
+
+Your root cause analysis is incomplete without must_gather validation. If your findings from ansible.log and logjuicer are not confirmed by must_gather data, state that explicitly.
+"""
+        else:
+            must_gather_instructions = ""
+
+        # -- Jira ticket instruction -------------------------------------------
+        if comment:
+            jira_instruction = (
+                f"\nCheck that the associated Jira ticket "
+                f"[{comment}](https://redhat.atlassian.net/browse/{comment}) "
+                f"is consistent with your findings.\n"
+            )
+        else:
+            jira_instruction = ""
+
         # -- Assemble full prompt ----------------------------------------------
         return f"""Conduct a root cause analysis (RCA) on DCI job [{dci_job_id}](https://distributed-ci.io/jobs/{dci_job_id}).
 
 Store all downloaded files at `/tmp/dci/{dci_job_id}/` to avoid re-downloading.
 Create a report at `/tmp/dci/rca-{dci_job_id}.md`.
-If there is a CILAB-<num> comment, replace it with `https://redhat.atlassian.net/browse/CILAB-<num>`.
 
 {job_context}
 {file_section}
@@ -501,14 +633,12 @@ Follow the prioritized file list above. For each file:
 1. Download it using its **file ID** (provided above).
 2. Analyze it according to its role described in the file list.
 3. For each difference flagged by logjuicer files, determine whether it is a **cause**, a **consequence**, or **unrelated** to the failure.
-
-If must_gather files are available, extract them with `tar -xf <file>` and use `omc use <extracted_dir>` to inspect cluster state.
-
+{must_gather_instructions}
 **Avoid** looking at DCI task files, `failed_task.txt`, or `play_recap` — they duplicate ansible.log content.
 
 Do not hesitate to download any extra files from the "Other files" or "Supporting files" sections that may be relevant.
 
-{_RCA_METHODOLOGY}"""
+{_RCA_METHODOLOGY}{jira_instruction}"""
 
     @mcp.prompt()
     async def weekly(

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -210,6 +210,7 @@ def _prioritize_files(
       P4 – *junit*
       P5 – *must_gather*.tar.gz
       P6 – *events.txt
+      P6b – *-console.log (bare-metal node console output)
       P7 – other *.log files
       P8 – supporting (everything else)
 
@@ -240,6 +241,7 @@ def _prioritize_files(
         "P4": [],
         "P5": [],
         "P6": [],
+        "P6b": [],
         "P7": [],
         "P8": [],
     }
@@ -263,6 +265,8 @@ def _prioritize_files(
             buckets["P5"].append(f)
         elif fnmatch.fnmatch(name, "*events.txt"):
             buckets["P6"].append(f)
+        elif fnmatch.fnmatch(name, "*-console.log"):
+            buckets["P6b"].append(f)
         elif fnmatch.fnmatch(name, "*.log"):
             buckets["P7"].append(f)
         else:
@@ -395,6 +399,11 @@ def _build_file_section(
         "install-config.yaml": "cluster install configuration",
         "agent-config.yaml": "agent-based installer configuration",
         "openshift_install.log": "openshift-install command output",
+        "bootkube.log": "control-plane bootstrap logs",
+        "ironic.log": "bare-metal provisioning (Ironic) logs",
+        "ironic-inspector.log": "bare-metal hardware inspection logs",
+        "ironic-ramdisk-logs.log": "bare-metal ramdisk (IPA) logs",
+        "cluster-bootstrap.log": "cluster bootstrap progress logs",
         "claim.json": "certsuite test claim report",
     }
 
@@ -453,6 +462,11 @@ def _build_file_section(
             "Event logs",
             "Kubernetes events timeline. Use to verify causal ordering.",
         ),
+        "P6b": (
+            "Console logs",
+            "Bare-metal node serial console output (BIOS, bootloader, kernel). "
+            "Check for hardware errors, boot failures, kernel panics, or storage issues.",
+        ),
         "P7": (
             "Other log files",
             "Additional log files that may contain relevant clues.",
@@ -483,7 +497,7 @@ def _build_file_section(
         return "**hub** cluster"
 
     seq = 0
-    for bucket_key in ("P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"):
+    for bucket_key in ("P1", "P2", "P3", "P4", "P5", "P6", "P6b", "P7", "P8"):
         bucket_files = buckets.get(bucket_key, [])
         if not bucket_files:
             continue

--- a/mcp_server/prompts/render.py
+++ b/mcp_server/prompts/render.py
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Render MCP prompts outside of an MCP server context.
+
+Provides ``render_prompt`` (async) and ``list_prompts`` (sync) for use
+by CLI tools and integration tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ..config import has_dci_credentials
+from .prompts import register_prompts
+
+has_dci_credentials()
+
+PromptFn = Callable[..., Any]
+
+
+def _collect_prompts() -> dict[str, PromptFn]:
+    """Register prompts on a lightweight stub and return the captured functions."""
+    captured: dict[str, PromptFn] = {}
+
+    class _FakeMCP:
+        @staticmethod
+        def prompt():
+            def decorator(fn):
+                captured[fn.__name__] = fn
+                return fn
+
+            return decorator
+
+    register_prompts(_FakeMCP())
+    return captured
+
+
+def list_prompts() -> list[str]:
+    """Return the names of all registered prompts."""
+    return sorted(_collect_prompts())
+
+
+async def render_prompt(name: str, **kwargs: str) -> str:
+    """Render a prompt by name with the given keyword arguments.
+
+    Raises:
+        ValueError: If *name* does not match any registered prompt.
+    """
+    prompts = _collect_prompts()
+    fn = prompts.get(name)
+    if fn is None:
+        available = ", ".join(sorted(prompts))
+        raise ValueError(f"Unknown prompt {name!r}. Available prompts: {available}")
+    return await fn(**kwargs)
+
+
+# render.py ends here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.scripts]
 dci-mcp-server = "mcp_server.main:main"
+dci-render-prompt = "mcp_server.prompts.__main__:main"
 
 [project.optional-dependencies]
 dev = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,4 @@ markers =
     integration: Integration tests
     slow: Slow running tests
     eval: Evaluation tests (require claude CLI and API keys)
+    rca_eval: RCA end-to-end evaluation (expensive, requires claude CLI and DCI credentials)

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -27,6 +27,7 @@ RUN_FORMAT=false
 RUN_LINT=false
 RUN_TEST=false
 RUN_CONTAINER=false
+RUN_RCA_EVAL=false
 
 if [ $# -eq 0 ]; then
     # No arguments: run all checks
@@ -48,9 +49,12 @@ else
             --container)
                 RUN_CONTAINER=true
                 ;;
+            --rca-eval)
+                RUN_RCA_EVAL=true
+                ;;
             *)
                 echo "❌ Unknown argument: $arg"
-                echo "Usage: $0 [--format] [--lint] [--test] [--container]"
+                echo "Usage: $0 [--format] [--lint] [--test] [--container] [--rca-eval]"
                 exit 1
                 ;;
         esac
@@ -103,7 +107,7 @@ if [ "$RUN_TEST" = true ]; then
         exit 1
     }
     echo "🧪 Running tests..."
-    $PYTHON_CMD -m pytest tests/ -v -m "not eval" || {
+    $PYTHON_CMD -m pytest tests/ -v -m "not eval and not rca_eval" || {
         echo "❌ Tests failed"
         exit 1
     }
@@ -146,6 +150,15 @@ if [ "$RUN_CONTAINER" = true ]; then
 
     echo "🧹 Cleaning up test images..."
     $CONTAINER_CMD rmi dci-mcp-server-test dci-mcp-server-sse-test 2>/dev/null || true
+fi
+
+# Run RCA end-to-end eval
+if [ "$RUN_RCA_EVAL" = true ]; then
+    echo "🔬 Running RCA end-to-end eval (this may take several minutes)..."
+    $PYTHON_CMD -m pytest tests/test_rca_eval.py -v -m "rca_eval" || {
+        echo "❌ RCA eval failed"
+        exit 1
+    }
 fi
 
 echo "🎉 All checks passed! ✨"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -96,8 +96,8 @@ class TestPrioritizeFiles:
     """Tests for _prioritize_files()."""
 
     @staticmethod
-    def _f(name, fid="id-1", size=1024):
-        return {"name": name, "id": fid, "size": size}
+    def _f(name, fid="id-1", size=1024, mime="text/plain"):
+        return {"name": name, "id": fid, "size": size, "mime": mime}
 
     def test_ansible_log_is_p1(self):
         result = _prioritize_files([self._f("ansible.log")])
@@ -116,8 +116,14 @@ class TestPrioritizeFiles:
         result = _prioritize_files([self._f("logjuicer_omg_SNO.txt")])
         assert len(result["P3"]) == 1
 
-    def test_junit_is_p4(self):
-        result = _prioritize_files([self._f("junit.xml")])
+    def test_junit_mime_is_p4(self):
+        result = _prioritize_files(
+            [self._f("dci-openshift-agent", mime="application/junit")]
+        )
+        assert len(result["P4"]) == 1
+
+    def test_junit_name_is_p4(self):
+        result = _prioritize_files([self._f("results.junit", mime="application/junit")])
         assert len(result["P4"]) == 1
 
     def test_must_gather_is_p5(self):
@@ -159,29 +165,29 @@ class TestPrioritizeFiles:
         total = sum(len(v) for v in result.values())
         assert total == 0
 
-    def test_uppercase_task_files_are_skipped(self):
+    def test_ansible_output_mime_is_skipped(self):
+        """Files with application/x-ansible-output MIME are skipped."""
         for name in [
             "TASK [Remove logs directory]",
             "TASK [Failure]",
             "failed/TASK [Fail properly]",
             "skipped/TASK [Run agent cleanup]",
             "failed/PLAY RECAP",
-            "skipped/TASK [Execute the failure process]",
+            "PLAY [all]",
+            "PLAYBOOK: site.yml",
         ]:
-            result = _prioritize_files([self._f(name)])
+            result = _prioritize_files(
+                [self._f(name, mime="application/x-ansible-output")]
+            )
             total = sum(len(v) for v in result.values())
-            assert total == 0, f"{name!r} should be skipped"
+            assert total == 0, f"{name!r} should be skipped via MIME type"
 
-    def test_dci_agent_files_are_skipped(self):
-        result = _prioritize_files([self._f("dci-openshift-app-agent")])
-        total = sum(len(v) for v in result.values())
-        assert total == 0
-
-    def test_play_and_playbook_files_are_skipped(self):
-        for name in ["PLAY [all]", "PLAY [Deploy cluster]", "PLAYBOOK: site.yml"]:
-            result = _prioritize_files([self._f(name)])
-            total = sum(len(v) for v in result.values())
-            assert total == 0, f"{name!r} should be skipped"
+    def test_dci_agent_junit_is_p4(self):
+        """DCI agent files with application/junit MIME go to P4."""
+        result = _prioritize_files(
+            [self._f("dci-openshift-app-agent", mime="application/junit")]
+        )
+        assert len(result["P4"]) == 1
 
     def test_hardware_and_kernel_files_are_skipped(self):
         for name in ["hardware.json", "hardware.txt", "kernel.log", "kernel.config"]:
@@ -190,32 +196,33 @@ class TestPrioritizeFiles:
             assert total == 0, f"{name!r} should be skipped"
 
     def test_mixed_file_list(self):
-        """Full scenario with various file types."""
+        """Full scenario with various file types and MIME types."""
         files = [
             self._f("ansible.log"),
             self._f("logjuicer.txt"),
             self._f("logjuicer_omg.txt"),
             self._f("logjuicer_omg_SNO.txt"),
-            self._f("junit.xml"),
-            self._f("must_gather.tar.gz"),
-            self._f("SNO_must_gather.tar.gz"),
+            self._f("dci-openshift-agent", mime="application/junit"),
+            self._f("must_gather.tar.gz", mime="application/x-gzip"),
+            self._f("SNO_must_gather.tar.gz", mime="application/x-gzip"),
             self._f("events.txt"),
+            self._f("cluster4-master-0-console.log"),
             self._f("custom.log"),
             self._f("config.yaml"),
             self._f("failed_task.txt"),
             self._f("play_recap"),
-            self._f("TASK [Remove logs directory]"),
-            self._f("failed/TASK [Fail properly]"),
-            self._f("skipped/TASK [Run agent cleanup]"),
-            self._f("dci-openshift-app-agent"),
+            self._f("TASK [Remove logs]", mime="application/x-ansible-output"),
+            self._f("failed/TASK [Fail]", mime="application/x-ansible-output"),
+            self._f("skipped/TASK [Run]", mime="application/x-ansible-output"),
         ]
         result = _prioritize_files(files)
         assert len(result["P1"]) == 1  # ansible.log
         assert len(result["P2"]) == 1  # logjuicer.txt
         assert len(result["P3"]) == 2  # logjuicer_omg*.txt
-        assert len(result["P4"]) == 1  # junit
+        assert len(result["P4"]) == 1  # dci-openshift-agent (junit)
         assert len(result["P5"]) == 2  # must_gather*
         assert len(result["P6"]) == 1  # events.txt
+        assert len(result["P6b"]) == 1  # console.log
         assert len(result["P7"]) == 1  # custom.log
         assert len(result["P8"]) == 1  # config.yaml
 
@@ -298,7 +305,7 @@ class TestBuildFileSection:
         buckets["P4"] = [{"name": "junit.xml", "id": "b", "size": 512}]
         section = _build_file_section(buckets)
         assert "### 1. Entry Point: ansible.log" in section
-        assert "### 2. Test results (JUnit)" in section
+        assert "### 2. Test results (application/junit)" in section
 
     def test_omg_without_must_gather_has_no_implied_note(self):
         """No implied note — it would trigger wasteful tool calls."""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -132,6 +132,10 @@ class TestPrioritizeFiles:
         result = _prioritize_files([self._f("events.txt")])
         assert len(result["P6"]) == 1
 
+    def test_console_log_is_p6b(self):
+        result = _prioritize_files([self._f("cluster4-master-0-console.log")])
+        assert len(result["P6b"]) == 1
+
     def test_other_log_is_p7(self):
         result = _prioritize_files([self._f("custom_output.log")])
         assert len(result["P7"]) == 1
@@ -270,12 +274,16 @@ class TestBuildFileSection:
     """Tests for _build_file_section()."""
 
     def test_empty_buckets(self):
-        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets = {
+            k: [] for k in ("P1", "P2", "P3", "P4", "P5", "P6", "P6b", "P7", "P8")
+        }
         section = _build_file_section(buckets)
         assert "No files found" in section
 
     def test_file_ids_appear_in_output(self):
-        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets = {
+            k: [] for k in ("P1", "P2", "P3", "P4", "P5", "P6", "P6b", "P7", "P8")
+        }
         buckets["P1"] = [{"name": "ansible.log", "id": "file-abc", "size": 2048}]
         section = _build_file_section(buckets)
         assert "file-abc" in section
@@ -283,7 +291,9 @@ class TestBuildFileSection:
 
     def test_sequential_numbering(self):
         """Non-empty buckets should be numbered sequentially."""
-        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets = {
+            k: [] for k in ("P1", "P2", "P3", "P4", "P5", "P6", "P6b", "P7", "P8")
+        }
         buckets["P1"] = [{"name": "ansible.log", "id": "a", "size": 1024}]
         buckets["P4"] = [{"name": "junit.xml", "id": "b", "size": 512}]
         section = _build_file_section(buckets)
@@ -292,7 +302,9 @@ class TestBuildFileSection:
 
     def test_omg_without_must_gather_has_no_implied_note(self):
         """No implied note — it would trigger wasteful tool calls."""
-        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets = {
+            k: [] for k in ("P1", "P2", "P3", "P4", "P5", "P6", "P6b", "P7", "P8")
+        }
         buckets["P1"] = [{"name": "ansible.log", "id": "a", "size": 1024}]
         buckets["P3"] = [{"name": "logjuicer_omg.txt", "id": "b", "size": 512}]
         section = _build_file_section(buckets)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -155,6 +155,36 @@ class TestPrioritizeFiles:
         total = sum(len(v) for v in result.values())
         assert total == 0
 
+    def test_uppercase_task_files_are_skipped(self):
+        for name in [
+            "TASK [Remove logs directory]",
+            "TASK [Failure]",
+            "failed/TASK [Fail properly]",
+            "skipped/TASK [Run agent cleanup]",
+            "failed/PLAY RECAP",
+            "skipped/TASK [Execute the failure process]",
+        ]:
+            result = _prioritize_files([self._f(name)])
+            total = sum(len(v) for v in result.values())
+            assert total == 0, f"{name!r} should be skipped"
+
+    def test_dci_agent_files_are_skipped(self):
+        result = _prioritize_files([self._f("dci-openshift-app-agent")])
+        total = sum(len(v) for v in result.values())
+        assert total == 0
+
+    def test_play_and_playbook_files_are_skipped(self):
+        for name in ["PLAY [all]", "PLAY [Deploy cluster]", "PLAYBOOK: site.yml"]:
+            result = _prioritize_files([self._f(name)])
+            total = sum(len(v) for v in result.values())
+            assert total == 0, f"{name!r} should be skipped"
+
+    def test_hardware_and_kernel_files_are_skipped(self):
+        for name in ["hardware.json", "hardware.txt", "kernel.log", "kernel.config"]:
+            result = _prioritize_files([self._f(name)])
+            total = sum(len(v) for v in result.values())
+            assert total == 0, f"{name!r} should be skipped"
+
     def test_mixed_file_list(self):
         """Full scenario with various file types."""
         files = [
@@ -170,6 +200,10 @@ class TestPrioritizeFiles:
             self._f("config.yaml"),
             self._f("failed_task.txt"),
             self._f("play_recap"),
+            self._f("TASK [Remove logs directory]"),
+            self._f("failed/TASK [Fail properly]"),
+            self._f("skipped/TASK [Run agent cleanup]"),
+            self._f("dci-openshift-app-agent"),
         ]
         result = _prioritize_files(files)
         assert len(result["P1"]) == 1  # ansible.log
@@ -247,15 +281,22 @@ class TestBuildFileSection:
         assert "file-abc" in section
         assert "ansible.log" in section
 
-    def test_all_priority_labels_present(self):
-        """Each non-empty bucket should have its header."""
+    def test_sequential_numbering(self):
+        """Non-empty buckets should be numbered sequentially."""
         buckets = {f"P{i}": [] for i in range(1, 9)}
         buckets["P1"] = [{"name": "ansible.log", "id": "a", "size": 1024}]
         buckets["P4"] = [{"name": "junit.xml", "id": "b", "size": 512}]
         section = _build_file_section(buckets)
-        assert "P1" in section
-        assert "P4" in section
-        assert "P2" not in section or "P2 —" not in section
+        assert "### 1. Entry Point: ansible.log" in section
+        assert "### 2. Test results (JUnit)" in section
+
+    def test_omg_without_must_gather_has_no_implied_note(self):
+        """No implied note — it would trigger wasteful tool calls."""
+        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets["P1"] = [{"name": "ansible.log", "id": "a", "size": 1024}]
+        buckets["P3"] = [{"name": "logjuicer_omg.txt", "id": "b", "size": 512}]
+        section = _build_file_section(buckets)
+        assert "implied" not in section.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,494 @@
+#
+# Copyright (C) 2025-2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for RCA prompt helpers and dynamic prompt generation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_server.prompts.prompts import (
+    _build_file_section,
+    _build_job_type_guidance,
+    _classify_job_type,
+    _fetch_job_files,
+    _fetch_job_metadata,
+    _prioritize_files,
+)
+
+# ---------------------------------------------------------------------------
+# _classify_job_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestClassifyJobType:
+    """Tests for _classify_job_type()."""
+
+    def test_acm_tag(self):
+        assert _classify_job_type(["install_type:acm", "daily"]) == "acm"
+
+    def test_acm_tag_case_insensitive(self):
+        assert _classify_job_type(["install_type:ACM"]) == "acm"
+
+    def test_ztp_tag(self):
+        assert _classify_job_type(["ztp", "daily"]) == "ztp"
+
+    def test_ztp_in_compound_tag(self):
+        assert _classify_job_type(["pipeline:ztp-deploy"]) == "ztp"
+
+    def test_upgrade_tag(self):
+        assert _classify_job_type(["upgrade", "nightly"]) == "upgrade"
+
+    def test_upgrade_in_compound_tag(self):
+        assert _classify_job_type(["pipeline:upgrade-4.16-to-4.17"]) == "upgrade"
+
+    def test_day2_agent_tag(self):
+        assert _classify_job_type(["agent:openshift-app"]) == "day2"
+
+    def test_day2_explicit_tag(self):
+        assert _classify_job_type(["day2-workload"]) == "day2"
+
+    def test_sno_tag(self):
+        assert _classify_job_type(["sno", "ga"]) == "sno"
+
+    def test_spoke_tag(self):
+        assert _classify_job_type(["spoke"]) == "sno"
+
+    def test_bespoke_does_not_match_spoke(self):
+        """'bespoke' should not be classified as SNO via loose 'spoke' matching."""
+        assert _classify_job_type(["bespoke"]) == "standard"
+
+    def test_standard_no_tags(self):
+        assert _classify_job_type([]) == "standard"
+
+    def test_standard_unrelated_tags(self):
+        assert _classify_job_type(["daily", "ga", "build:ga"]) == "standard"
+
+    def test_acm_takes_priority_over_sno(self):
+        """ACM should win when both acm and sno tags are present."""
+        assert _classify_job_type(["install_type:acm", "sno"]) == "acm"
+
+    def test_ztp_takes_priority_over_upgrade(self):
+        """ZTP should win over upgrade in priority order."""
+        assert _classify_job_type(["ztp", "upgrade"]) == "ztp"
+
+
+# ---------------------------------------------------------------------------
+# _prioritize_files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPrioritizeFiles:
+    """Tests for _prioritize_files()."""
+
+    @staticmethod
+    def _f(name, fid="id-1", size=1024):
+        return {"name": name, "id": fid, "size": size}
+
+    def test_ansible_log_is_p1(self):
+        result = _prioritize_files([self._f("ansible.log")])
+        assert len(result["P1"]) == 1
+        assert result["P1"][0]["name"] == "ansible.log"
+
+    def test_logjuicer_txt_is_p2(self):
+        result = _prioritize_files([self._f("logjuicer.txt")])
+        assert len(result["P2"]) == 1
+
+    def test_logjuicer_omg_is_p3(self):
+        result = _prioritize_files([self._f("logjuicer_omg.txt")])
+        assert len(result["P3"]) == 1
+
+    def test_logjuicer_omg_sno_is_p3(self):
+        result = _prioritize_files([self._f("logjuicer_omg_SNO.txt")])
+        assert len(result["P3"]) == 1
+
+    def test_junit_is_p4(self):
+        result = _prioritize_files([self._f("junit.xml")])
+        assert len(result["P4"]) == 1
+
+    def test_must_gather_is_p5(self):
+        result = _prioritize_files([self._f("must_gather.tar.gz")])
+        assert len(result["P5"]) == 1
+
+    def test_sno_must_gather_is_p5(self):
+        result = _prioritize_files([self._f("SNO_must_gather.tar.gz")])
+        assert len(result["P5"]) == 1
+
+    def test_events_txt_is_p6(self):
+        result = _prioritize_files([self._f("events.txt")])
+        assert len(result["P6"]) == 1
+
+    def test_other_log_is_p7(self):
+        result = _prioritize_files([self._f("custom_output.log")])
+        assert len(result["P7"]) == 1
+
+    def test_other_file_is_p8(self):
+        result = _prioritize_files([self._f("config.yaml")])
+        assert len(result["P8"]) == 1
+
+    def test_failed_task_is_skipped(self):
+        result = _prioritize_files([self._f("failed_task.txt")])
+        total = sum(len(v) for v in result.values())
+        assert total == 0
+
+    def test_play_recap_is_skipped(self):
+        result = _prioritize_files([self._f("play_recap")])
+        total = sum(len(v) for v in result.values())
+        assert total == 0
+
+    def test_task_files_are_skipped(self):
+        result = _prioritize_files([self._f("task_001")])
+        total = sum(len(v) for v in result.values())
+        assert total == 0
+
+    def test_mixed_file_list(self):
+        """Full scenario with various file types."""
+        files = [
+            self._f("ansible.log"),
+            self._f("logjuicer.txt"),
+            self._f("logjuicer_omg.txt"),
+            self._f("logjuicer_omg_SNO.txt"),
+            self._f("junit.xml"),
+            self._f("must_gather.tar.gz"),
+            self._f("SNO_must_gather.tar.gz"),
+            self._f("events.txt"),
+            self._f("custom.log"),
+            self._f("config.yaml"),
+            self._f("failed_task.txt"),
+            self._f("play_recap"),
+        ]
+        result = _prioritize_files(files)
+        assert len(result["P1"]) == 1  # ansible.log
+        assert len(result["P2"]) == 1  # logjuicer.txt
+        assert len(result["P3"]) == 2  # logjuicer_omg*.txt
+        assert len(result["P4"]) == 1  # junit
+        assert len(result["P5"]) == 2  # must_gather*
+        assert len(result["P6"]) == 1  # events.txt
+        assert len(result["P7"]) == 1  # custom.log
+        assert len(result["P8"]) == 1  # config.yaml
+
+
+# ---------------------------------------------------------------------------
+# _build_job_type_guidance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildJobTypeGuidance:
+    """Tests for _build_job_type_guidance()."""
+
+    def test_acm_guidance_mentions_managedcluster(self):
+        guidance = _build_job_type_guidance("acm", [])
+        assert "ManagedCluster" in guidance
+        assert "hub/spoke" in guidance.lower() or "hub" in guidance.lower()
+
+    def test_ztp_guidance_mentions_siteconfig(self):
+        guidance = _build_job_type_guidance("ztp", [])
+        assert "SiteConfig" in guidance
+        assert "TALM" in guidance
+
+    def test_upgrade_guidance_mentions_clusterversion(self):
+        guidance = _build_job_type_guidance("upgrade", [])
+        assert "ClusterVersion" in guidance
+
+    def test_upgrade_guidance_includes_ocp_versions(self):
+        components = [
+            {"type": "ocp", "version": "4.16.3", "name": "OCP-4.16.3"},
+            {"type": "storage", "version": "1.0", "name": "ocs"},
+        ]
+        guidance = _build_job_type_guidance("upgrade", components)
+        assert "4.16.3" in guidance
+
+    def test_day2_guidance_mentions_day2(self):
+        guidance = _build_job_type_guidance("day2", [])
+        assert "day-2" in guidance.lower() or "day2" in guidance.lower()
+
+    def test_sno_guidance_mentions_single_node(self):
+        guidance = _build_job_type_guidance("sno", [])
+        assert "Single Node" in guidance or "single node" in guidance.lower()
+
+    def test_standard_returns_empty(self):
+        guidance = _build_job_type_guidance("standard", [])
+        assert guidance == ""
+
+
+# ---------------------------------------------------------------------------
+# _build_file_section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildFileSection:
+    """Tests for _build_file_section()."""
+
+    def test_empty_buckets(self):
+        buckets = {f"P{i}": [] for i in range(1, 9)}
+        section = _build_file_section(buckets)
+        assert "No files found" in section
+
+    def test_file_ids_appear_in_output(self):
+        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets["P1"] = [{"name": "ansible.log", "id": "file-abc", "size": 2048}]
+        section = _build_file_section(buckets)
+        assert "file-abc" in section
+        assert "ansible.log" in section
+
+    def test_all_priority_labels_present(self):
+        """Each non-empty bucket should have its header."""
+        buckets = {f"P{i}": [] for i in range(1, 9)}
+        buckets["P1"] = [{"name": "ansible.log", "id": "a", "size": 1024}]
+        buckets["P4"] = [{"name": "junit.xml", "id": "b", "size": 512}]
+        section = _build_file_section(buckets)
+        assert "P1" in section
+        assert "P4" in section
+        assert "P2" not in section or "P2 —" not in section
+
+
+# ---------------------------------------------------------------------------
+# _fetch_job_metadata (with mocked service)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFetchJobMetadata:
+    """Tests for _fetch_job_metadata()."""
+
+    @patch("mcp_server.prompts.prompts.DCIJobService")
+    def test_successful_fetch(self, mock_cls):
+        mock_service = MagicMock()
+        mock_cls.return_value = mock_service
+        mock_service.search_jobs.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_source": {
+                            "id": "job-1",
+                            "tags": ["daily", "install_type:acm"],
+                            "components": [
+                                {"type": "ocp", "name": "OCP", "version": "4.16.3"}
+                            ],
+                            "pipeline": {"name": "acm-deploy"},
+                            "status_reason": "Task failed",
+                            "status": "failure",
+                            "topic": {"name": "OCP-4.16"},
+                        }
+                    }
+                ]
+            }
+        }
+        result = _fetch_job_metadata("job-1")
+        assert result is not None
+        assert result["tags"] == ["daily", "install_type:acm"]
+        assert result["pipeline_name"] == "acm-deploy"
+        assert result["status"] == "failure"
+
+    @patch("mcp_server.prompts.prompts.DCIJobService")
+    def test_empty_hits_returns_none(self, mock_cls):
+        mock_service = MagicMock()
+        mock_cls.return_value = mock_service
+        mock_service.search_jobs.return_value = {"hits": {"hits": []}}
+        assert _fetch_job_metadata("nonexistent") is None
+
+    @patch("mcp_server.prompts.prompts.DCIJobService")
+    def test_exception_returns_none(self, mock_cls):
+        mock_cls.side_effect = Exception("connection error")
+        assert _fetch_job_metadata("job-1") is None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_job_files (with mocked service)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFetchJobFiles:
+    """Tests for _fetch_job_files()."""
+
+    @patch("mcp_server.prompts.prompts.DCIJobService")
+    def test_successful_fetch(self, mock_cls):
+        """Verify successful API call returns a list of file dicts."""
+        mock_service = MagicMock()
+        mock_cls.return_value = mock_service
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "files": [
+                {"id": "f1", "name": "ansible.log", "size": 4096},
+                {"id": "f2", "name": "junit.xml", "size": 512},
+            ]
+        }
+        # Patch the dciclient import inside _fetch_job_files
+        with patch("dciclient.v1.api.job.list_files", return_value=mock_response):
+            result = _fetch_job_files("job-1")
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["name"] == "ansible.log"
+
+    @patch("mcp_server.prompts.prompts.DCIJobService")
+    def test_exception_returns_none(self, mock_cls):
+        """Verify API exception returns None (not empty list)."""
+        mock_cls.side_effect = Exception("connection error")
+        assert _fetch_job_files("job-1") is None
+
+    @patch("mcp_server.prompts.prompts.DCIJobService")
+    def test_api_failure_returns_none_not_empty_list(self, mock_cls):
+        """Verify that API failures return None, not [], so the fallback
+        to static prompt can trigger correctly."""
+        mock_service = MagicMock()
+        mock_cls.return_value = mock_service
+        # Simulate the DCI API raising an exception (not swallowed)
+        with patch(
+            "dciclient.v1.api.job.list_files", side_effect=Exception("HTTP 500")
+        ):
+            result = _fetch_job_files("job-1")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# rca() integration test (mocked services)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRcaPromptIntegration:
+    """Integration tests for the rca() prompt function."""
+
+    @pytest.mark.asyncio
+    @patch("mcp_server.prompts.prompts._fetch_job_files")
+    @patch("mcp_server.prompts.prompts._fetch_job_metadata")
+    async def test_dynamic_prompt_with_metadata_and_files(self, mock_meta, mock_files):
+        """When metadata and files are available, the prompt is dynamic."""
+        mock_meta.return_value = {
+            "tags": ["install_type:acm", "daily"],
+            "components": [{"type": "ocp", "name": "OCP", "version": "4.16.3"}],
+            "pipeline_name": "acm-deploy",
+            "status_reason": "Task 'deploy' failed",
+            "status": "failure",
+            "topic_name": "OCP-4.16",
+        }
+        mock_files.return_value = [
+            {"id": "f1", "name": "ansible.log", "size": 4096},
+            {"id": "f2", "name": "logjuicer.txt", "size": 2048},
+            {"id": "f3", "name": "logjuicer_omg.txt", "size": 1024},
+            {"id": "f4", "name": "logjuicer_omg_SNO.txt", "size": 1024},
+            {"id": "f5", "name": "junit.xml", "size": 512},
+            {"id": "f6", "name": "must_gather.tar.gz", "size": 1048576},
+        ]
+
+        from mcp_server.prompts.prompts import register_prompts
+
+        mcp = MagicMock()
+        prompts_registered = {}
+
+        def fake_prompt():
+            def decorator(fn):
+                prompts_registered[fn.__name__] = fn
+                return fn
+
+            return decorator
+
+        mcp.prompt = fake_prompt
+        register_prompts(mcp)
+
+        rca_fn = prompts_registered["rca"]
+        result = await rca_fn("job-abc-123")
+
+        # Dynamic content checks
+        assert "job-abc-123" in result
+        assert "acm-deploy" in result
+        assert "OCP-4.16" in result
+        assert "failure" in result
+        assert "Task 'deploy' failed" in result
+        # File IDs should be referenced
+        assert "f1" in result
+        assert "f2" in result
+        assert "f3" in result
+        # ACM-specific guidance
+        assert "ManagedCluster" in result
+        # Methodology sections still present
+        assert "5 Whys" in result
+        assert "Adversarial Challenge" in result
+
+    @pytest.mark.asyncio
+    @patch("mcp_server.prompts.prompts._fetch_job_files")
+    @patch("mcp_server.prompts.prompts._fetch_job_metadata")
+    async def test_fallback_to_static_prompt(self, mock_meta, mock_files):
+        """When both fetches fail, fall back to the static prompt."""
+        mock_meta.return_value = None
+        mock_files.return_value = None
+
+        from mcp_server.prompts.prompts import register_prompts
+
+        mcp = MagicMock()
+        prompts_registered = {}
+
+        def fake_prompt():
+            def decorator(fn):
+                prompts_registered[fn.__name__] = fn
+                return fn
+
+            return decorator
+
+        mcp.prompt = fake_prompt
+        register_prompts(mcp)
+
+        rca_fn = prompts_registered["rca"]
+        result = await rca_fn("job-xyz-789")
+
+        # Static prompt should still work
+        assert "job-xyz-789" in result
+        assert "5 Whys" in result
+        assert "Adversarial Challenge" in result
+        # Should NOT have dynamic sections
+        assert "Job Context" not in result
+        assert "Available Files" not in result
+
+    @pytest.mark.asyncio
+    @patch("mcp_server.prompts.prompts._fetch_job_files")
+    @patch("mcp_server.prompts.prompts._fetch_job_metadata")
+    async def test_partial_failure_files_only(self, mock_meta, mock_files):
+        """When metadata fails but files succeed, still build dynamic prompt."""
+        mock_meta.return_value = None
+        mock_files.return_value = [
+            {"id": "f1", "name": "ansible.log", "size": 4096},
+        ]
+
+        from mcp_server.prompts.prompts import register_prompts
+
+        mcp = MagicMock()
+        prompts_registered = {}
+
+        def fake_prompt():
+            def decorator(fn):
+                prompts_registered[fn.__name__] = fn
+                return fn
+
+            return decorator
+
+        mcp.prompt = fake_prompt
+        register_prompts(mcp)
+
+        rca_fn = prompts_registered["rca"]
+        result = await rca_fn("job-partial")
+
+        # Should have dynamic file section
+        assert "Available Files" in result
+        assert "f1" in result
+        # Should have job context even with defaults
+        assert "Job Context" in result
+
+
+# test_prompts.py ends here

--- a/tests/test_rca_eval.py
+++ b/tests/test_rca_eval.py
@@ -1,0 +1,339 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""End-to-end evaluation of the RCA prompt with LLM judge.
+
+Runs a full RCA with Claude on a real DCI job, then uses an LLM judge
+to score the report against the RCA methodology criteria.
+
+Run with: uv run pytest -m rca_eval -v
+Or:       bash scripts/run-checks.sh --rca-eval
+"""
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+project_root = Path(__file__).parent.parent
+load_dotenv(project_root / ".env", override=True)
+
+JOB_ID = "7fb9d2e5-c5d0-4134-8416-02c79af4617d"
+REPORT_PATH = Path(f"/tmp/dci/rca-{JOB_ID}.md")
+
+JUDGE_PROMPT = """\
+You are an expert judge evaluating the quality of a Root Cause Analysis (RCA) \
+report for a CI/CD job failure. Score the report on each criterion below \
+using 0, 1, or 2.
+
+## Scoring rubric
+
+1. **causal_depth**: How deep is the causal chain?
+   - 0: Stops at the first error (symptom only)
+   - 1: 2-3 levels of "why"
+   - 2: 4+ levels with evidence at each level
+
+2. **evidence_quality**: Are claims backed by specific log evidence?
+   - 0: No log citations or file references
+   - 1: Some file references but vague
+   - 2: Specific log lines or file content cited at each causal level
+
+3. **adversarial_challenge**: Was an alternative hypothesis explored?
+   - 0: No alternative hypothesis mentioned
+   - 1: Alternative mentioned but not investigated with evidence
+   - 2: Alternative from a different failure category, investigated with evidence for/against
+
+4. **confidence_calibration**: Is confidence level stated with justification?
+   - 0: No confidence level stated
+   - 1: Confidence stated but criteria not explained
+   - 2: Confidence stated with evidence-based justification (what evidence supports it, what's missing)
+
+5. **report_structure**: Does the report have the required sections?
+   Required: Job Information, Failure Symptom, Causal Chain, Root Cause, \
+Contributing Factors, Confidence Level, Recommendations
+   - 0: Fewer than 4 of the 7 sections
+   - 1: 4-5 sections present
+   - 2: 6-7 sections present
+
+6. **must_gather_usage**: Was must_gather / cluster state data used?
+   - 0: Not referenced at all
+   - 1: Referenced but not integrated as evidence in the causal chain
+   - 2: must_gather findings used as supporting or refuting evidence
+
+7. **actionable_recommendations**: Are the recommendations useful?
+   - 0: Missing or completely generic ("fix the bug")
+   - 1: Some specific recommendations
+   - 2: Concrete, actionable recommendations linked to the identified root cause
+
+## Output format
+
+Return ONLY a JSON object with this exact structure, no other text:
+```json
+{
+  "scores": {
+    "causal_depth": <0-2>,
+    "evidence_quality": <0-2>,
+    "adversarial_challenge": <0-2>,
+    "confidence_calibration": <0-2>,
+    "report_structure": <0-2>,
+    "must_gather_usage": <0-2>,
+    "actionable_recommendations": <0-2>
+  },
+  "explanations": {
+    "causal_depth": "<one sentence>",
+    "evidence_quality": "<one sentence>",
+    "adversarial_challenge": "<one sentence>",
+    "confidence_calibration": "<one sentence>",
+    "report_structure": "<one sentence>",
+    "must_gather_usage": "<one sentence>",
+    "actionable_recommendations": "<one sentence>"
+  },
+  "overall_assessment": "<2-3 sentence summary of the report quality>"
+}
+```
+
+## Report to evaluate
+
+"""
+
+
+def _has_dci_credentials():
+    return bool(os.getenv("DCI_CLIENT_ID") and os.getenv("DCI_API_SECRET"))
+
+
+def _has_claude_cli():
+    return shutil.which("claude") is not None
+
+
+skip_no_credentials = pytest.mark.skipif(
+    not _has_dci_credentials(),
+    reason="DCI credentials not available",
+)
+
+skip_no_claude = pytest.mark.skipif(
+    not _has_claude_cli(),
+    reason="claude CLI not available",
+)
+
+
+def _render_rca_prompt():
+    from mcp_server.prompts.render import render_prompt
+
+    return asyncio.run(render_prompt("rca", dci_job_id=JOB_ID))
+
+
+def _run_rca(prompt):
+    mcp_config = json.dumps(
+        {
+            "mcpServers": {
+                "dci": {
+                    "command": "uv",
+                    "args": ["run", "main.py"],
+                    "cwd": str(project_root),
+                }
+            }
+        }
+    )
+
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        os.getenv("EVAL_MODEL", "sonnet"),
+        "--no-session-persistence",
+        "--strict-mcp-config",
+        "--dangerously-skip-permissions",
+        "--max-budget-usd",
+        "2.00",
+        "--mcp-config",
+        mcp_config,
+        "--allowed-tools",
+        "mcp__dci__search_dci_jobs",
+        "mcp__dci__download_dci_file",
+        "mcp__dci__get_jira_ticket",
+        "Bash",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            cwd=str(project_root),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("RCA eval timed out (600s)")
+
+    messages = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            messages.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    return messages, result.returncode
+
+
+def _run_judge(report):
+    """Run the LLM judge on the report and return parsed scores."""
+    prompt = JUDGE_PROMPT + report
+    empty_mcp = json.dumps({"mcpServers": {}})
+
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        os.getenv("JUDGE_MODEL", "haiku"),
+        "--no-session-persistence",
+        "--strict-mcp-config",
+        "--mcp-config",
+        empty_mcp,
+        "--max-budget-usd",
+        "0.10",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(project_root),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("Judge timed out (120s)")
+
+    answer = ""
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            if msg.get("type") == "result":
+                answer = msg.get("result", "")
+                break
+        except json.JSONDecodeError:
+            continue
+
+    if not answer and result.stderr:
+        pytest.fail(f"Judge failed: {result.stderr[:500]}")
+
+    # Extract JSON from the answer (may be wrapped in markdown code fence)
+    json_match = re.search(r"\{[\s\S]*\}", answer)
+    if not json_match:
+        pytest.fail(f"Judge did not return valid JSON. Response: {answer[:500]}")
+
+    try:
+        return json.loads(json_match.group())
+    except json.JSONDecodeError:
+        pytest.fail(f"Judge returned invalid JSON: {json_match.group()[:500]}")
+
+
+CRITERIA = [
+    "causal_depth",
+    "evidence_quality",
+    "adversarial_challenge",
+    "confidence_calibration",
+    "report_structure",
+    "must_gather_usage",
+    "actionable_recommendations",
+]
+
+
+@pytest.mark.rca_eval
+@skip_no_credentials
+@skip_no_claude
+class TestRcaEval:
+    """End-to-end RCA evaluation with LLM judge."""
+
+    @pytest.fixture(scope="class")
+    def rca_report(self):
+        """Run the RCA once and return the report text."""
+        if REPORT_PATH.exists():
+            REPORT_PATH.unlink()
+
+        prompt = _render_rca_prompt()
+        messages, _ = _run_rca(prompt)
+
+        cost = 0.0
+        num_turns = 0
+        for msg in messages:
+            if msg.get("type") == "result":
+                cost = msg.get("total_cost_usd", 0)
+                num_turns = msg.get("num_turns", 0)
+                break
+
+        print(f"\n  [rca] cost=${cost:.4f}, turns={num_turns}")
+
+        assert REPORT_PATH.exists(), f"Report not found at {REPORT_PATH}"
+        report = REPORT_PATH.read_text()
+        assert len(report) > 500, "Report is too short"
+        return report
+
+    @pytest.fixture(scope="class")
+    def judge_scores(self, rca_report):
+        """Run the LLM judge on the report and return scores."""
+        result = _run_judge(rca_report)
+
+        scores = result.get("scores", {})
+        explanations = result.get("explanations", {})
+        overall = result.get("overall_assessment", "")
+
+        print(f"\n  [judge] Overall: {overall}")
+        for criterion in CRITERIA:
+            score = scores.get(criterion, "?")
+            explanation = explanations.get(criterion, "")
+            print(f"  [judge] {criterion}: {score}/2 — {explanation}")
+
+        avg = sum(scores.get(c, 0) for c in CRITERIA) / len(CRITERIA)
+        print(f"  [judge] Average: {avg:.2f}/2.0")
+
+        return scores
+
+    def test_report_exists_and_has_job_id(self, rca_report):
+        assert JOB_ID in rca_report
+
+    def test_no_criterion_scores_zero(self, judge_scores):
+        """Every criterion must score at least 1 (partial)."""
+        for criterion in CRITERIA:
+            score = judge_scores.get(criterion, 0)
+            assert score >= 1, f"{criterion} scored 0 — failing quality gate"
+
+    def test_average_score_above_threshold(self, judge_scores):
+        """Average score across all criteria must be >= 1.0."""
+        avg = sum(judge_scores.get(c, 0) for c in CRITERIA) / len(CRITERIA)
+        assert avg >= 1.0, f"Average score {avg:.2f} below threshold 1.0"
+
+
+# test_rca_eval.py ends here

--- a/tests/test_rca_prompt_integration.py
+++ b/tests/test_rca_prompt_integration.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Integration tests for the RCA prompt dynamic section selection.
+
+These tests use real DCI job IDs to verify that the RCA prompt renders
+the correct job-type guidance, file inventory, and job context sections.
+Tests that hit the DCI API require credentials and are skipped otherwise.
+"""
+
+import pytest
+
+from mcp_server.config import has_dci_credentials
+from mcp_server.prompts.render import list_prompts, render_prompt
+
+_has_dci_credentials = has_dci_credentials()
+
+requires_dci = pytest.mark.skipif(
+    not _has_dci_credentials,
+    reason="DCI credentials not available (DCI_CLIENT_ID / DCI_API_SECRET)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Real DCI job IDs for each job-type classification
+# ---------------------------------------------------------------------------
+
+# install_type:acm tag → classified as "acm"
+ACM_JOB_ID = "7fb9d2e5-c5d0-4134-8416-02c79af4617d"
+
+# ztp tag + install_type:abi (no install_type:acm) → classified as "ztp"
+ZTP_JOB_ID = "78738e75-d359-4a86-9522-489522ceaa2e"
+
+# upgrade tag → classified as "upgrade"
+UPGRADE_JOB_ID = "bdbf3496-fabb-43ee-a2f9-4d699a3f626e"
+
+# agent:openshift-app tag → classified as "day2" (also has sno, but day2 wins)
+DAY2_JOB_ID = "f94beb63-3269-4d91-a27e-357245d7631d"
+
+# sno + install_type:sno (no acm/ztp/upgrade/day2 tags) → classified as "sno"
+SNO_JOB_ID = "d232e2e5-99e2-4156-b20f-360e7ad8f801"
+
+# No special tags (virt, daily, install_type:abi) → classified as "standard"
+STANDARD_JOB_ID = "bd8f228e-302c-4298-96e9-a429a6547d71"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real DCI API calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@requires_dci
+class TestRcaPromptJobTypeSelection:
+    """Verify that real DCI jobs produce the correct dynamic RCA prompt."""
+
+    @pytest.mark.asyncio
+    async def test_acm_job_produces_acm_guidance(self):
+        result = await render_prompt("rca", dci_job_id=ACM_JOB_ID)
+        assert "Job-Type Guidance: ACM" in result
+        assert "ManagedCluster" in result
+        assert "Job Context" in result
+        assert "Job-Type Guidance: ZTP" not in result
+        assert "Job-Type Guidance: Upgrade" not in result
+
+    @pytest.mark.asyncio
+    async def test_ztp_job_produces_ztp_guidance(self):
+        result = await render_prompt("rca", dci_job_id=ZTP_JOB_ID)
+        assert "Job-Type Guidance: ZTP" in result
+        assert "SiteConfig" in result
+        assert "TALM" in result
+        assert "Job Context" in result
+        assert "ManagedCluster" not in result
+
+    @pytest.mark.asyncio
+    async def test_upgrade_job_produces_upgrade_guidance(self):
+        result = await render_prompt("rca", dci_job_id=UPGRADE_JOB_ID)
+        assert "Job-Type Guidance: Upgrade" in result
+        assert "ClusterVersion" in result
+        assert "Job Context" in result
+        assert "ManagedCluster" not in result
+        assert "SiteConfig" not in result
+
+    @pytest.mark.asyncio
+    async def test_day2_job_produces_day2_guidance(self):
+        result = await render_prompt("rca", dci_job_id=DAY2_JOB_ID)
+        assert "Job-Type Guidance: Day-2" in result
+        assert "Job Context" in result
+        assert "ManagedCluster" not in result
+        assert "SiteConfig" not in result
+
+    @pytest.mark.asyncio
+    async def test_sno_job_produces_sno_guidance(self):
+        result = await render_prompt("rca", dci_job_id=SNO_JOB_ID)
+        assert "Job-Type Guidance: SNO" in result
+        assert "Single Node" in result
+        assert "Job Context" in result
+        assert "ManagedCluster" not in result
+        assert "SiteConfig" not in result
+
+    @pytest.mark.asyncio
+    async def test_standard_job_has_no_job_type_guidance(self):
+        result = await render_prompt("rca", dci_job_id=STANDARD_JOB_ID)
+        assert "Job Context" in result
+        assert "Job-Type Guidance:" not in result
+        assert "ManagedCluster" not in result
+        assert "SiteConfig" not in result
+
+    @pytest.mark.asyncio
+    async def test_dynamic_prompt_has_file_section(self):
+        """Any real job should produce a file inventory section."""
+        result = await render_prompt("rca", dci_job_id=ACM_JOB_ID)
+        assert "Available Files" in result
+
+    @pytest.mark.asyncio
+    async def test_dynamic_prompt_has_methodology(self):
+        """The shared RCA methodology should always be present."""
+        result = await render_prompt("rca", dci_job_id=ACM_JOB_ID)
+        assert "5 Whys" in result
+        assert "Adversarial Challenge" in result
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no DCI credentials needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRenderPromptLibrary:
+    """Tests for the render_prompt library functions."""
+
+    def test_list_prompts_includes_all(self):
+        names = list_prompts()
+        assert "rca" in names
+        assert "weekly" in names
+        assert "biweekly" in names
+        assert "quarterly" in names
+
+    @pytest.mark.asyncio
+    async def test_render_weekly_prompt(self):
+        result = await render_prompt("weekly", subject="test-team")
+        assert "test-team" in result
+        assert "week" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_render_unknown_prompt_raises(self):
+        with pytest.raises(ValueError, match="Unknown prompt 'nonexistent'"):
+            await render_prompt("nonexistent")
+
+
+# test_rca_prompt_integration.py ends here


### PR DESCRIPTION
## Summary

- Make the RCA prompt dynamically select which job files to analyze based on job type classification (ACM, ZTP, upgrade, day2, SNO, standard)
- Add intelligent file filtering using configurable rules that match job tags to relevant log files and artifacts
- Add comprehensive test coverage for the new dynamic prompt generation logic

## Changes

- **mcp_server/prompts/prompts.py**: Added job metadata/file fetching, job type classification from tags, configurable file selection rules per job type, and dynamic RCA prompt generation that tailors file selection to the job context
- **tests/test_prompts.py**: Added 467 lines of tests covering job classification, file matching, rule-based selection, and end-to-end prompt generation

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)