### PR TITLE
Enhance JiraService with user field resolution

### DIFF
--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -53,6 +53,8 @@ class JiraService:
         else:
             self.jira = JIRA(server=self.jira_url, token_auth=self.jira_token)
         self._field_map: dict[str, str] | None = None
+        self._user_field_ids: set[str] | None = None
+        self._multi_user_field_ids: set[str] | None = None
         self._status_name_map: dict[str, str] | None = None
         self._is_cloud = "atlassian.net" in self.jira_url
 
@@ -176,13 +178,31 @@ class JiraService:
             return None
 
     def _get_field_map(self) -> dict[str, str]:
-        """Get field ID to name mapping, cached per instance."""
+        """Get field ID to name mapping, cached per instance.
+
+        Also populates ``_user_field_ids`` and ``_multi_user_field_ids``
+        so that ``update_issue`` can resolve user-type custom fields.
+        """
         if self._field_map is None:
             try:
                 fields = self.jira.fields()
-                self._field_map = {f["id"]: f["name"] for f in fields}
+                self._field_map = {}
+                user_ids: set[str] = set()
+                multi_user_ids: set[str] = set()
+                for f in fields:
+                    self._field_map[f["id"]] = f["name"]
+                    schema = f.get("schema", {})
+                    custom = schema.get("custom", "")
+                    if schema.get("type") == "user" or custom.endswith(":userpicker"):
+                        user_ids.add(f["id"])
+                    elif custom.endswith(":multiuserpicker"):
+                        multi_user_ids.add(f["id"])
+                self._user_field_ids = user_ids
+                self._multi_user_field_ids = multi_user_ids
             except Exception:
                 self._field_map = {}
+                self._user_field_ids = set()
+                self._multi_user_field_ids = set()
         return self._field_map
 
     def get_ticket_data(
@@ -578,8 +598,19 @@ class JiraService:
             if custom_fields:
                 field_map = self._get_field_map()
                 name_to_id = {v: k for k, v in field_map.items()}
+                user_ids = self._user_field_ids or set()
+                multi_user_ids = self._multi_user_field_ids or set()
                 for key, value in custom_fields.items():
                     field_id = name_to_id.get(key, key)
+                    if field_id in user_ids and isinstance(value, str):
+                        value = self._resolve_assignee(value)
+                    elif field_id in multi_user_ids and isinstance(value, str):
+                        names = [n.strip() for n in value.split(",") if n.strip()]
+                        value = [
+                            resolved
+                            for n in names
+                            if (resolved := self._resolve_assignee(n)) is not None
+                        ]
                     fields[field_id] = value
 
             if fields:

--- a/mcp_server/tools/jira_write_tools.py
+++ b/mcp_server/tools/jira_write_tools.py
@@ -142,8 +142,11 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
                     "Dictionary of custom field IDs (customfield_NNNNN) or "
                     "human-readable field names to values. Supports Forge/Connect "
                     "app fields (e.g. encrypted select fields). "
+                    "User picker fields (e.g. QA Contact) are auto-resolved "
+                    "from display names or emails. "
+                    "For multi-user fields, pass comma-separated names. "
                     "Use list_jira_custom_field_options to discover valid values. "
-                    'Example: {"customfield_12345": "some value"}'
+                    'Example: {"QA Contact": "Jane Doe"}'
                 )
             ),
         ] = None,

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -134,8 +134,12 @@ def _make_jira_service():
 def test_get_field_map_caching():
     svc = _make_jira_service()
     svc.jira.fields.return_value = [
-        {"id": "customfield_10001", "name": "Sprint"},
-        {"id": "customfield_10002", "name": "Story Points"},
+        {"id": "customfield_10001", "name": "Sprint", "schema": {"type": "string"}},
+        {
+            "id": "customfield_10002",
+            "name": "Story Points",
+            "schema": {"type": "number"},
+        },
     ]
 
     result1 = svc._get_field_map()
@@ -1036,3 +1040,161 @@ def test_search_child_tickets_no_matching_stories():
     assert result["total_grandparents"] == 1
     assert result["total_intermediates"] == 1
     assert result["total_tickets"] == 0
+
+
+# -- user-type custom field resolution in update_issue --
+
+
+def test_get_field_map_detects_user_fields():
+    """_get_field_map populates _user_field_ids and _multi_user_field_ids."""
+    svc = _make_jira_service()
+    svc.jira.fields.return_value = [
+        {
+            "id": "customfield_10470",
+            "name": "QA Contact",
+            "schema": {
+                "type": "user",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:userpicker",
+            },
+        },
+        {
+            "id": "customfield_10466",
+            "name": "Contributors",
+            "schema": {
+                "type": "array",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker",
+            },
+        },
+        {
+            "id": "customfield_10001",
+            "name": "Sprint",
+            "schema": {"type": "string"},
+        },
+    ]
+
+    svc._get_field_map()
+
+    assert "customfield_10470" in svc._user_field_ids
+    assert "customfield_10466" in svc._multi_user_field_ids
+    assert "customfield_10001" not in svc._user_field_ids
+    assert "customfield_10001" not in svc._multi_user_field_ids
+
+
+def test_update_issue_resolves_user_picker_field():
+    """User picker custom fields are resolved to {"accountId": ...}."""
+    svc = _make_jira_service()
+    svc._is_cloud = True
+    mock_issue = MagicMock()
+    svc.jira.issue.return_value = mock_issue
+    svc.jira.fields.return_value = [
+        {
+            "id": "customfield_10470",
+            "name": "QA Contact",
+            "schema": {
+                "type": "user",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:userpicker",
+            },
+        },
+    ]
+
+    put_resp = MagicMock()
+    put_resp.status_code = 204
+    get_resp = MagicMock()
+    get_resp.json.return_value = [{"accountId": "abc123"}]
+    rendered_resp = MagicMock()
+    rendered_resp.json.return_value = {"renderedFields": {}}
+
+    def route_get(url, **kwargs):
+        if "user/search" in url:
+            return get_resp
+        return rendered_resp
+
+    svc.jira._session.put.return_value = put_resp
+    svc.jira._session.get.side_effect = route_get
+
+    result = svc.update_issue(
+        "TEST-123",
+        custom_fields={"QA Contact": "Jane Doe"},
+    )
+
+    call_json = svc.jira._session.put.call_args[1]["json"]
+    assert call_json["fields"]["customfield_10470"] == {"accountId": "abc123"}
+    assert result["status"] == "updated"
+
+
+def test_update_issue_resolves_multi_user_picker_field():
+    """Multi-user picker custom fields are resolved to a list."""
+    svc = _make_jira_service()
+    svc._is_cloud = True
+    mock_issue = MagicMock()
+    svc.jira.issue.return_value = mock_issue
+    svc.jira.fields.return_value = [
+        {
+            "id": "customfield_10466",
+            "name": "Contributors",
+            "schema": {
+                "type": "array",
+                "custom": "com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker",
+            },
+        },
+    ]
+
+    put_resp = MagicMock()
+    put_resp.status_code = 204
+    rendered_resp = MagicMock()
+    rendered_resp.json.return_value = {"renderedFields": {}}
+
+    call_count = 0
+
+    def route_get(url, **kwargs):
+        nonlocal call_count
+        if "user/search" in url:
+            call_count += 1
+            resp = MagicMock()
+            resp.json.return_value = [{"accountId": f"user{call_count}"}]
+            return resp
+        return rendered_resp
+
+    svc.jira._session.put.return_value = put_resp
+    svc.jira._session.get.side_effect = route_get
+
+    svc.update_issue(
+        "TEST-123",
+        custom_fields={"Contributors": "Alice, Bob"},
+    )
+
+    call_json = svc.jira._session.put.call_args[1]["json"]
+    assert call_json["fields"]["customfield_10466"] == [
+        {"accountId": "user1"},
+        {"accountId": "user2"},
+    ]
+
+
+def test_update_issue_skips_resolution_for_non_user_fields():
+    """Non-user custom fields are passed through unchanged."""
+    svc = _make_jira_service()
+    svc._is_cloud = True
+    mock_issue = MagicMock()
+    svc.jira.issue.return_value = mock_issue
+    svc.jira.fields.return_value = [
+        {
+            "id": "customfield_10983",
+            "name": "Escape Reason",
+            "schema": {"type": "string"},
+        },
+    ]
+
+    put_resp = MagicMock()
+    put_resp.status_code = 204
+    rendered_resp = MagicMock()
+    rendered_resp.json.return_value = {"renderedFields": {}}
+    svc.jira._session.put.return_value = put_resp
+    svc.jira._session.get.return_value = rendered_resp
+
+    svc.update_issue(
+        "TEST-123",
+        custom_fields={"Escape Reason": "Test doesn't exist"},
+    )
+
+    call_json = svc.jira._session.put.call_args[1]["json"]
+    assert call_json["fields"]["customfield_10983"] == "Test doesn't exist"


### PR DESCRIPTION
- Add support for resolving user and multi-user custom fields
- Populate `_user_field_ids` and `_multi_user_field_ids` in `_get_field_map`
- Extend `update_issue` to resolve user-type fields using `_resolve_assignee`
- Update documentation and examples for handling user picker fields
- Implement tests for detecting user fields and resolving user picker fields
