### PR TITLE
Add Jira issue link functionalities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # DCI MCP Server - Change Log
 
+## [2026-07-03]
+
+### New Features
+
+- Add `add_jira_issue_link` tool: create typed links between Jira tickets (e.g., "Blocks", "Clones", "Duplicates")
+- Add `list_jira_issue_link_types` tool: discover available link types for the Jira instance
+
 ## [2026-06-07]
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -352,7 +352,10 @@ Enabled by default. Set `DATE_TOOLS_ENABLED=false` to disable.
 - `create_jira_ticket(project_key, summary, ...)`: Create a new Jira ticket with optional description, issue type, priority, labels, components, and assignee
 - `update_jira_ticket(ticket_key, ...)`: Update ticket fields (summary, description, priority, labels, components, assignee) or transition status
 - `add_jira_comment(ticket_key, body)`: Add a comment to a ticket
+- `add_jira_issue_link(ticket_key, target_ticket_key, link_type)`: Create a typed link between two tickets (e.g., "Blocks", "Clones", "Duplicates"). Use `list_jira_issue_link_types` to discover available link types
+- `add_jira_weblink(ticket_key, url, title)`: Add a web/remote link to a ticket
 - `list_jira_transitions(ticket_key)`: List available workflow transitions for a ticket
+- `list_jira_issue_link_types()`: List available issue link types with their inward/outward descriptions
 
 **Note**: Jira write tools require both `JIRA_API_TOKEN` and `JIRA_WRITE_ENABLED=true` environment variables.
 

--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -702,6 +702,60 @@ class JiraService:
         except Exception as e:
             raise Exception(f"Error adding web link to {ticket_key}: {str(e)}") from e
 
+    def add_issue_link(
+        self, link_type: str, inward_issue: str, outward_issue: str
+    ) -> dict[str, Any]:
+        """Create an issue link between two Jira tickets.
+
+        Args:
+            link_type: Link type name (e.g., "Blocks"). Use
+                get_issue_link_types() to discover available types.
+            inward_issue: Inward issue key (e.g., "PROJ-123").
+            outward_issue: Outward issue key (e.g., "PROJ-456").
+
+        Returns:
+            Dictionary with the created link details.
+        """
+        try:
+            self.jira.create_issue_link(
+                type=link_type,
+                inwardIssue=inward_issue,
+                outwardIssue=outward_issue,
+            )
+            return {
+                "inward_issue": inward_issue,
+                "outward_issue": outward_issue,
+                "link_type": link_type,
+            }
+        except JIRAError as e:
+            raise Exception(f"Jira API error: {e.text}") from e
+        except Exception as e:
+            raise Exception(
+                f"Error creating issue link between "
+                f"{inward_issue} and {outward_issue}: {str(e)}"
+            ) from e
+
+    def get_issue_link_types(self) -> list[dict[str, str]]:
+        """Get available issue link types for this Jira instance.
+
+        Returns:
+            List of dicts with name, inward, and outward descriptions.
+        """
+        try:
+            link_types = self.jira.issue_link_types()
+            return [
+                {
+                    "name": lt.name,
+                    "inward": lt.inward,
+                    "outward": lt.outward,
+                }
+                for lt in link_types
+            ]
+        except JIRAError as e:
+            raise Exception(f"Jira API error: {e.text}") from e
+        except Exception as e:
+            raise Exception(f"Error fetching issue link types: {str(e)}") from e
+
     def get_transitions(self, ticket_key: str) -> list[dict[str, Any]]:
         """
         Get available workflow transitions for a Jira issue.

--- a/mcp_server/tools/jira_introspect_tools.py
+++ b/mcp_server/tools/jira_introspect_tools.py
@@ -145,6 +145,27 @@ def register_jira_introspect_tools(mcp: FastMCP) -> None:
             return json.dumps({"error": str(e)}, indent=2)
 
     @mcp.tool()
+    async def list_jira_issue_link_types() -> str:
+        """List available issue link types for this Jira instance.
+
+        Returns the link types that can be used with add_jira_issue_link,
+        including the inward and outward descriptions for each type.
+
+        For example, a "Blocks" link type has:
+        - inward: "is blocked by"
+        - outward: "blocks"
+
+        Returns:
+            JSON string with list of link types
+        """
+        try:
+            jira_service = JiraService()
+            result = jira_service.get_issue_link_types()
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
     async def list_jira_boards(
         project_key: Annotated[
             str | None,

--- a/mcp_server/tools/jira_write_tools.py
+++ b/mcp_server/tools/jira_write_tools.py
@@ -302,6 +302,70 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
             return json.dumps({"error": str(e)}, indent=2)
 
     @mcp.tool()
+    async def add_jira_issue_link(
+        ticket_key: Annotated[
+            str,
+            Field(
+                description="Jira ticket key for the inward side of the link "
+                "(e.g., CILAB-1234)"
+            ),
+        ],
+        target_ticket_key: Annotated[
+            str,
+            Field(
+                description="Jira ticket key for the outward side of the link "
+                "(e.g., CILAB-5678)"
+            ),
+        ],
+        link_type: Annotated[
+            str,
+            Field(
+                description='Link type name (e.g., "Blocks"). '
+                "Use list_jira_issue_link_types to discover available types."
+            ),
+        ],
+    ) -> str:
+        """Create an issue link between two Jira tickets.
+
+        Links two tickets with a typed relationship such as "Blocks",
+        "Clones", or "Duplicates". The link is directional: ticket_key
+        is the inward issue and target_ticket_key is the outward issue.
+
+        For example, with link_type="Blocks":
+        - ticket_key "is blocked by" target_ticket_key (inward)
+        - target_ticket_key "blocks" ticket_key (outward)
+
+        Use list_jira_issue_link_types to discover available link type
+        names and their inward/outward descriptions.
+
+        ## Authentication Required
+
+        Requires `JIRA_API_TOKEN` and `JIRA_WRITE_ENABLED=true` environment variables.
+
+        ## Returned Data
+
+        Returns a JSON object with:
+        - **inward_issue**: The inward ticket key
+        - **outward_issue**: The outward ticket key
+        - **link_type**: The link type name used
+
+        Returns:
+            JSON string with link data
+        """
+        try:
+            normalized_key = validate_ticket_key(ticket_key)
+            normalized_target = validate_ticket_key(target_ticket_key)
+            jira_service = JiraService()
+            result = jira_service.add_issue_link(
+                link_type, normalized_key, normalized_target
+            )
+            return json.dumps(result, indent=2)
+        except ValueError as e:
+            return json.dumps({"error": str(e)}, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
     async def list_jira_custom_field_options(
         ticket_key: Annotated[
             str,

--- a/tests/test_jira_tools.py
+++ b/tests/test_jira_tools.py
@@ -18,6 +18,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from jira.exceptions import JIRAError
 
 from mcp_server.services.jira_service import JiraService, _simplify_field_value
 from mcp_server.tools.jira_tools import validate_ticket_key
@@ -1198,3 +1199,75 @@ def test_update_issue_skips_resolution_for_non_user_fields():
 
     call_json = svc.jira._session.put.call_args[1]["json"]
     assert call_json["fields"]["customfield_10983"] == "Test doesn't exist"
+
+
+# -- add_issue_link tests --
+
+
+def test_add_issue_link():
+    svc = _make_jira_service()
+    svc.jira.create_issue_link.return_value = None
+
+    result = svc.add_issue_link("Blocks", "TEST-123", "TEST-456")
+
+    svc.jira.create_issue_link.assert_called_once_with(
+        type="Blocks",
+        inwardIssue="TEST-123",
+        outwardIssue="TEST-456",
+    )
+    assert result == {
+        "inward_issue": "TEST-123",
+        "outward_issue": "TEST-456",
+        "link_type": "Blocks",
+    }
+
+
+def test_add_issue_link_api_error():
+    svc = _make_jira_service()
+    error = JIRAError(text="Link type not found")
+    svc.jira.create_issue_link.side_effect = error
+
+    with pytest.raises(Exception, match="Jira API error"):
+        svc.add_issue_link("InvalidType", "TEST-123", "TEST-456")
+
+
+# -- get_issue_link_types tests --
+
+
+def test_get_issue_link_types():
+    svc = _make_jira_service()
+
+    blocks_type = MagicMock()
+    blocks_type.name = "Blocks"
+    blocks_type.inward = "is blocked by"
+    blocks_type.outward = "blocks"
+
+    clones_type = MagicMock()
+    clones_type.name = "Cloners"
+    clones_type.inward = "is cloned by"
+    clones_type.outward = "clones"
+
+    svc.jira.issue_link_types.return_value = [blocks_type, clones_type]
+
+    result = svc.get_issue_link_types()
+
+    assert len(result) == 2
+    assert result[0] == {
+        "name": "Blocks",
+        "inward": "is blocked by",
+        "outward": "blocks",
+    }
+    assert result[1] == {
+        "name": "Cloners",
+        "inward": "is cloned by",
+        "outward": "clones",
+    }
+
+
+def test_get_issue_link_types_empty():
+    svc = _make_jira_service()
+    svc.jira.issue_link_types.return_value = []
+
+    result = svc.get_issue_link_types()
+
+    assert result == []


### PR DESCRIPTION
- Implement `add_issue_link` in JiraService to link Jira tickets
- Create `get_issue_link_types` in JiraService to fetch link types
- Add `add_jira_issue_link` tool for ticket linking via API
- Implement `list_jira_issue_link_types` tool to list link types
- Develop tests for new link-related methods in JiraService
