### PR TITLE
Add intermediate JQL support and update MCP dependency

### DIFF
--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -878,6 +878,7 @@ class JiraService:
         child_jql: str,
         parent_link_field: str = "parent",
         child_link_field: str = "parentEpic",
+        intermediate_jql: str | None = None,
         max_results: int = 200,
     ) -> dict[str, Any]:
         """Traverse a 2-level Jira hierarchy and return leaf tickets with ancestry.
@@ -920,6 +921,8 @@ class JiraService:
             int_to_gp: dict[str, str] = {}
             for gp_key in gp_keys:
                 jql = f"{parent_link_field} = {gp_key}"
+                if intermediate_jql:
+                    jql += f" AND {intermediate_jql}"
                 issues = self._search_all(jql, "summary,status")
                 for issue in issues:
                     int_data = {

--- a/mcp_server/tools/jira_tools.py
+++ b/mcp_server/tools/jira_tools.py
@@ -350,6 +350,13 @@ def register_jira_tools(mcp: FastMCP) -> None:
                 description='Jira field linking leaf tickets to intermediates (default: "parentEpic")'
             ),
         ] = "parentEpic",
+        intermediate_jql: Annotated[
+            str | None,
+            Field(
+                description="Optional JQL filter applied to intermediate-level tickets. "
+                'Example: "labels = my-label"'
+            ),
+        ] = None,
         max_results: Annotated[
             int,
             Field(
@@ -363,7 +370,7 @@ def register_jira_tools(mcp: FastMCP) -> None:
 
         Performs a top-down search through three levels of Jira tickets:
         1. **Grandparents** (level 0): Found via `parent_jql`
-        2. **Intermediates** (level 1): Found via `{parent_link_field} = <grandparent key>`
+        2. **Intermediates** (level 1): Found via `{parent_link_field} = <grandparent key>` (optionally filtered by `intermediate_jql`)
         3. **Leaves** (level 2): Found via `{child_link_field} = <intermediate key> AND {child_jql}`
 
         Each leaf ticket includes its full ancestry (parent and grandparent keys,
@@ -396,6 +403,7 @@ def register_jira_tools(mcp: FastMCP) -> None:
                 child_jql=child_jql,
                 parent_link_field=parent_link_field,
                 child_link_field=child_link_field,
+                intermediate_jql=intermediate_jql,
                 max_results=max_results,
             )
             return json.dumps(results, indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "DCI MCP Server"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "mcp>=1.28.1",
     "fastmcp>=2.11.3",
     "httpx>=0.28.1",
     "python-dateutil>=2.9.0.post0",

--- a/uv.lock
+++ b/uv.lock
@@ -354,6 +354,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jira" },
     { name = "markdown" },
+    { name = "mcp" },
     { name = "pydantic" },
     { name = "pygithub" },
     { name = "python-dateutil" },
@@ -406,6 +407,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "jira", specifier = ">=3.8.0" },
     { name = "markdown", specifier = ">=3.7.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pygithub", specifier = ">=2.8.1" },
@@ -1031,7 +1033,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1049,9 +1051,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Enhance Jira service to support optional intermediate JQL filters
  when traversing ticket hierarchies
- Update tools to handle new intermediate JQL parameter
- Increase MCP dependency version to 1.28.1 in pyproject.toml and
  lock files to ensure compatibility with new features
