### PR TITLE
feat: add Google Drive read/write tools and Jira security level support

### DIFF
--- a/mcp_server/services/google_drive_service.py
+++ b/mcp_server/services/google_drive_service.py
@@ -12,14 +12,17 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from googleapiclient.http import MediaIoBaseUpload
+from googleapiclient.http import MediaIoBaseUpload, MediaIoBaseDownload
 
 
 class GoogleDriveService:
     """Service for interacting with Google Drive API."""
 
     # If modifying these scopes, delete the file token.json.
-    SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+    SCOPES = [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/documents"
+    ]
 
     def __init__(
         self, credentials_path: str | None = None, token_path: str | None = None
@@ -68,6 +71,8 @@ class GoogleDriveService:
             os.chmod(self.token_path, 0o600)
 
         self.service = build("drive", "v3", credentials=creds)
+        self.docs_service = build("docs", "v1", credentials=creds)
+        self.sheets_service = build("sheets", "v4", credentials=creds)
 
     def markdown_to_html(self, markdown_content: str) -> str:
         """
@@ -90,6 +95,144 @@ class GoogleDriveService:
             ]
         )
         return md.convert(markdown_content)
+
+    def read_google_doc(self, file_id: str) -> str:
+        """Read a Google Doc and return its text content."""
+        try:
+            request = self.service.files().export_media(fileId=file_id, mimeType='text/plain')
+            fh = io.BytesIO()
+            downloader = MediaIoBaseDownload(fh, request)
+            done = False
+            while done is False:
+                status, done = downloader.next_chunk()
+            return fh.getvalue().decode('utf-8')
+        except HttpError as error:
+            raise Exception(f"Error reading Google Doc: {error.resp.status} - {error.content}") from error
+
+    def read_google_sheet(
+        self,
+        spreadsheet_id: str,
+        sheet_name: str | None = None,
+        cell_range: str | None = None,
+    ) -> dict:
+        """Read data from a Google Spreadsheet.
+
+        Args:
+            spreadsheet_id: The spreadsheet ID (from the URL).
+            sheet_name: Specific sheet/tab name. Reads the first sheet if omitted.
+            cell_range: A1 notation range (e.g. "A1:D10"). Reads all data if omitted.
+
+        Returns:
+            Dict with sheet metadata, headers, rows, and a CSV representation.
+        """
+        try:
+            metadata = (
+                self.sheets_service.spreadsheets()
+                .get(spreadsheetId=spreadsheet_id)
+                .execute()
+            )
+            title = metadata.get("properties", {}).get("title", "")
+            sheets = metadata.get("sheets", [])
+
+            if not sheet_name and sheets:
+                sheet_name = sheets[0]["properties"]["title"]
+
+            range_notation = f"'{sheet_name}'"
+            if cell_range:
+                range_notation = f"'{sheet_name}'!{cell_range}"
+
+            result = (
+                self.sheets_service.spreadsheets()
+                .values()
+                .get(spreadsheetId=spreadsheet_id, range=range_notation)
+                .execute()
+            )
+
+            values = result.get("values", [])
+            headers = values[0] if values else []
+            rows = values[1:] if len(values) > 1 else []
+
+            # Pad short rows to match header length
+            for i, row in enumerate(rows):
+                if len(row) < len(headers):
+                    rows[i] = row + [""] * (len(headers) - len(row))
+
+            csv_lines = []
+            if headers:
+                csv_lines.append(",".join(f'"{h}"' for h in headers))
+            for row in rows:
+                csv_lines.append(",".join(f'"{c}"' for c in row))
+
+            available_sheets = [s["properties"]["title"] for s in sheets]
+
+            return {
+                "spreadsheet_title": title,
+                "sheet_name": sheet_name,
+                "available_sheets": available_sheets,
+                "headers": headers,
+                "row_count": len(rows),
+                "rows": rows,
+                "csv": "\n".join(csv_lines),
+            }
+        except HttpError as error:
+            raise Exception(
+                f"Error reading Google Sheet: {error.resp.status} - {error.content}"
+            ) from error
+
+    def append_to_google_doc(self, file_id: str, text_content: str) -> dict:
+        """Append text to the end of a Google Doc."""
+        try:
+            doc = self.docs_service.documents().get(documentId=file_id).execute()
+            body_content = doc.get('body', {}).get('content', [])
+            end_index = body_content[-1].get('endIndex', 2) - 1
+            
+            requests = [
+                {
+                    'insertText': {
+                        'location': {
+                            'index': max(1, end_index)
+                        },
+                        'text': "\\n" + text_content
+                    }
+                }
+            ]
+            
+            response = self.docs_service.documents().batchUpdate(
+                documentId=file_id, body={'requests': requests}
+            ).execute()
+            
+            return {
+                "id": file_id,
+                "url": f"https://docs.google.com/document/d/{file_id}/edit",
+                "status": "success",
+                "appended_chars": len(text_content)
+            }
+        except HttpError as error:
+            raise Exception(f"Error appending to Google Doc: {error.resp.status} - {error.content}") from error
+
+    def prepend_to_google_doc(self, file_id: str, text_content: str) -> dict:
+        """Insert text at the beginning of a Google Doc."""
+        try:
+            requests = [
+                {
+                    'insertText': {
+                        'location': {
+                            'index': 1
+                        },
+                        'text': text_content + "\\n\\n"
+                    }
+                }
+            ]
+            response = self.docs_service.documents().batchUpdate(
+                documentId=file_id, body={'requests': requests}
+            ).execute()
+            return {
+                "id": file_id,
+                "url": f"https://docs.google.com/document/d/{file_id}/edit",
+                "status": "success"
+            }
+        except HttpError as error:
+            raise Exception(f"Error prepending to Google Doc: {error.resp.status} - {error.content}") from error
 
     def find_folder_by_name(
         self, folder_name: str, include_shared_drives: bool = True

--- a/mcp_server/services/jira_service.py
+++ b/mcp_server/services/jira_service.py
@@ -520,6 +520,7 @@ class JiraService:
         labels: list[str] | None = None,
         components: list[str] | None = None,
         assignee: str | None = None,
+        security_level: str | None = None,
     ) -> dict[str, Any]:
         """
         Create a new Jira issue.
@@ -543,6 +544,8 @@ class JiraService:
                 fields["components"] = [{"name": c} for c in components]
             if assignee is not None:
                 fields["assignee"] = self._resolve_assignee(assignee)
+            if security_level is not None:
+                fields["security"] = {"name": security_level}
 
             issue = self.jira.create_issue(fields=fields)
             return {
@@ -566,6 +569,7 @@ class JiraService:
         assignee: str | None = None,
         transition: str | None = None,
         custom_fields: dict[str, Any] | None = None,
+        security_level: str | None = None,
     ) -> dict[str, Any]:
         """
         Update an existing Jira issue.
@@ -573,6 +577,7 @@ class JiraService:
         Args:
             custom_fields: Dict mapping customfield_NNNNN IDs (or human-readable
                 names) to values. Supports Forge/Connect app fields.
+            security_level: Security level name (e.g., "Red Hat Employee").
 
         Returns:
             Dictionary with updated issue information
@@ -594,6 +599,9 @@ class JiraService:
                 fields["components"] = [{"name": c} for c in components]
             if assignee is not None:
                 fields["assignee"] = self._resolve_assignee(assignee)
+
+            if security_level is not None:
+                fields["security"] = {"name": security_level}
 
             # Resolve human-readable custom field names to IDs
             if custom_fields:

--- a/mcp_server/tools/google_drive_tools.py
+++ b/mcp_server/tools/google_drive_tools.py
@@ -222,9 +222,124 @@ def register_google_drive_tools(mcp: FastMCP) -> None:
                 return json.dumps(
                     {
                         "found": False,
-                        "message": f"Folder '{folder_name}' not found in Google Drive{' or shared drives' if include_shared_drives else ''}",
+                        "message": f"Folder '{folder_name}' not found",
                     },
                     indent=2,
                 )
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
+    async def read_google_doc(
+        file_id: Annotated[
+            str,
+            Field(description="The ID of the Google Doc to read (found in the URL)"),
+        ]
+    ) -> str:
+        """
+        Read the text content of a Google Doc.
+        
+        This tool extracts the plain text from a Google Doc given its ID.
+        Useful for reading existing meeting notes, templates, or reports.
+        
+        Returns:
+            JSON string containing the text content or an error message.
+        """
+        try:
+            service = GoogleDriveService()
+            text_content = service.read_google_doc(file_id)
+            return json.dumps({"content": text_content, "id": file_id}, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
+    async def read_google_sheet(
+        spreadsheet_id: Annotated[
+            str,
+            Field(
+                description="The ID of the Google Spreadsheet to read (found in the URL between /d/ and /edit)"
+            ),
+        ],
+        sheet_name: Annotated[
+            str | None,
+            Field(
+                description="Name of the specific sheet/tab to read. Reads the first sheet if omitted."
+            ),
+        ] = None,
+        cell_range: Annotated[
+            str | None,
+            Field(
+                description="A1 notation range to limit what is read (e.g. 'A1:D10'). Reads all data if omitted."
+            ),
+        ] = None,
+    ) -> str:
+        """
+        Read data from a Google Spreadsheet.
+
+        Returns the spreadsheet content as structured JSON with headers, rows,
+        and a CSV representation. Also lists all available sheet/tab names
+        in the spreadsheet so you can query specific tabs.
+
+        Returns:
+            JSON string with sheet metadata, headers, rows, and CSV content.
+        """
+        try:
+            service = GoogleDriveService()
+            result = service.read_google_sheet(spreadsheet_id, sheet_name, cell_range)
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
+    async def append_to_google_doc(
+        file_id: Annotated[
+            str,
+            Field(description="The ID of the Google Doc to append to"),
+        ],
+        text_content: Annotated[
+            str,
+            Field(description="The text to append to the end of the document"),
+        ]
+    ) -> str:
+        """
+        Append text to the end of an existing Google Doc.
+        
+        This tool inserts new text at the very end of the document.
+        Useful for adding new meeting notes to a running document.
+        
+        Returns:
+            JSON string with status information.
+        """
+        try:
+            service = GoogleDriveService()
+            result = service.append_to_google_doc(file_id, text_content)
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)}, indent=2)
+
+    @mcp.tool()
+    async def prepend_to_google_doc(
+        file_id: Annotated[
+            str,
+            Field(description="The ID of the Google Doc to prepend to"),
+        ],
+        text_content: Annotated[
+            str,
+            Field(description="The text to insert at the beginning of the document"),
+        ]
+    ) -> str:
+        """
+        Insert text at the beginning of an existing Google Doc.
+        
+        This tool inserts new text at the very top of the document.
+        Useful for adding the newest weekly report to the top of a running document.
+        
+        Returns:
+            JSON string with status information.
+        """
+        try:
+            service = GoogleDriveService()
+            result = service.prepend_to_google_doc(file_id, text_content)
+            return json.dumps(result, indent=2)
         except Exception as e:
             return json.dumps({"error": str(e)}, indent=2)

--- a/mcp_server/tools/jira_write_tools.py
+++ b/mcp_server/tools/jira_write_tools.py
@@ -53,6 +53,12 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
                 description="Assignee username (Jira Server/DC) or account ID (Jira Cloud)"
             ),
         ] = None,
+        security_level: Annotated[
+            str | None,
+            Field(
+                description="Security level name (e.g., 'Red Hat Employee'). Must match a level defined in the project's security scheme."
+            ),
+        ] = None,
     ) -> str:
         """Create a new Jira ticket.
 
@@ -84,6 +90,7 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
                 labels=labels,
                 components=components,
                 assignee=assignee,
+                security_level=security_level,
             )
             return json.dumps(result, indent=2)
         except Exception as e:
@@ -150,6 +157,12 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
                 )
             ),
         ] = None,
+        security_level: Annotated[
+            str | None,
+            Field(
+                description="Security level name (e.g., 'Red Hat Employee'). Must match a level defined in the project's security scheme."
+            ),
+        ] = None,
     ) -> str:
         """Update an existing Jira ticket.
 
@@ -192,6 +205,7 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
                     assignee,
                     transition,
                     custom_fields,
+                    security_level,
                 ]
             ):
                 return json.dumps(
@@ -210,6 +224,7 @@ def register_jira_write_tools(mcp: FastMCP) -> None:
                 assignee=assignee,
                 transition=transition,
                 custom_fields=custom_fields,
+                security_level=security_level,
             )
             return json.dumps(result, indent=2)
         except ValueError as e:


### PR DESCRIPTION
## Summary

- Add `read_google_doc`, `read_google_sheet`, `append_to_google_doc`, and `prepend_to_google_doc` MCP tools for interacting with existing Google Drive documents and spreadsheets.
- Broaden OAuth scopes from `drive.file` to `drive` + `documents` to support reading/writing arbitrary user files (not just app-created ones).
- Add `security_level` parameter to `create_jira_ticket` and `update_jira_ticket` for projects using Jira security schemes (e.g., "Red Hat Employee" visibility).